### PR TITLE
Reproducible BTagSF

### DIFF
--- a/packages/BTagSFUtil/BTagSFUtil.C
+++ b/packages/BTagSFUtil/BTagSFUtil.C
@@ -9,9 +9,9 @@
 
 using namespace std;
 
-BTagSFUtil::BTagSFUtil(string MeasurementType, string BTagAlgorithm, TString OperatingPoint, int SystematicIndex, TString FastSimDataset, int Seed) {
+BTagSFUtil::BTagSFUtil(string MeasurementType, string BTagAlgorithm, TString OperatingPoint, int SystematicIndex, TString FastSimDataset) {
 
-  rand_ = new TRandom3(Seed);
+  //rand_ = new TRandom3(Seed);
 
   string CSVFileName = (string)gSystem->ExpandPathName("$PWD") + "/packages/BTagSFUtil/" + BTagAlgorithm + ".csv";
   const BTagCalibration calib(BTagAlgorithm, CSVFileName);
@@ -37,10 +37,6 @@ BTagSFUtil::BTagSFUtil(string MeasurementType, string BTagAlgorithm, TString Ope
     if (TaggerName=="CSV") TaggerCut = 0.244;
     //if (TaggerName=="CSVv2") TaggerCut = 0.605;
     if (TaggerName=="CSVv2") TaggerCut = 0.5426; // for Moriond17
-    //reader_bc = new BTagCalibrationReader(calib, BTagEntry::OP_LOOSE, MeasurementType, SystematicFlagBC);
-    //reader_l  = new BTagCalibrationReader(calib, BTagEntry::OP_LOOSE, MeasurementType, SystematicFlagL);
-    //reader_l  = new BTagCalibrationReader(calib, BTagEntry::OP_LOOSE, "comb", SystematicFlagL);
-    //reader_l  = new BTagCalibrationReader(calib, BTagEntry::OP_LOOSE, "incl", SystematicFlagL);  // comb-->incl
     reader_b = new BTagCalibrationReader(BTagEntry::OP_LOOSE, "central", sysTypes);
     reader_b -> load(calib, BTagEntry::FLAV_B, MeasurementType);
     reader_c = new BTagCalibrationReader(BTagEntry::OP_LOOSE, "central", sysTypes);
@@ -53,10 +49,6 @@ BTagSFUtil::BTagSFUtil(string MeasurementType, string BTagAlgorithm, TString Ope
     //if (TaggerName=="CSVv2") TaggerCut = 0.890; // for 74X
     //if (TaggerName=="CSVv2") TaggerCut = 0.800; // for 76X
     if (TaggerName=="CSVv2") TaggerCut = 0.8484; // for Moriond17
-    //reader_bc = new BTagCalibrationReader(calib, BTagEntry::OP_MEDIUM, MeasurementType, SystematicFlagBC);
-    //reader_l  = new BTagCalibrationReader(calib, BTagEntry::OP_MEDIUM, MeasurementType, SystematicFlagL);
-    //reader_l  = new BTagCalibrationReader(calib, BTagEntry::OP_MEDIUM,  "comb", SystematicFlagL);
-    //reader_l  = new BTagCalibrationReader(calib, BTagEntry::OP_MEDIUM,  "incl", SystematicFlagL);  // comb-->incl
     reader_b = new BTagCalibrationReader(BTagEntry::OP_MEDIUM, "central", sysTypes);
     reader_b -> load(calib, BTagEntry::FLAV_B, MeasurementType);
     reader_c = new BTagCalibrationReader(BTagEntry::OP_MEDIUM, "central", sysTypes);
@@ -69,10 +61,6 @@ BTagSFUtil::BTagSFUtil(string MeasurementType, string BTagAlgorithm, TString Ope
     if (TaggerName=="TCHP") TaggerCut = 3.41;
     //if (TaggerName=="CSVv2") TaggerCut = 0.970;
     if (TaggerName=="CSVv2") TaggerCut = 0.9535; // for Moriond17
-    //reader_bc = new BTagCalibrationReader(calib, BTagEntry::OP_TIGHT, MeasurementType, SystematicFlagBC);
-    //reader_l  = new BTagCalibrationReader(calib, BTagEntry::OP_TIGHT, MeasurementType, SystematicFlagL);
-    //reader_l  = new BTagCalibrationReader(calib, BTagEntry::OP_TIGHT, "comb", SystematicFlagL);
-    //reader_l  = new BTagCalibrationReader(calib, BTagEntry::OP_TIGHT, "incl", SystematicFlagL);  // comb-->incl
     reader_b = new BTagCalibrationReader(BTagEntry::OP_TIGHT, "central", sysTypes);
     reader_b -> load(calib, BTagEntry::FLAV_B, MeasurementType);
     reader_c = new BTagCalibrationReader(BTagEntry::OP_TIGHT, "central", sysTypes);
@@ -95,7 +83,7 @@ BTagSFUtil::BTagSFUtil(string MeasurementType, string BTagAlgorithm, TString Ope
 
 BTagSFUtil::~BTagSFUtil() {
 
-  delete rand_;
+  delete reader_b, reader_c, reader_l;
 
 }
 
@@ -160,7 +148,7 @@ float BTagSFUtil::GetJetSF(float JetDiscriminant, int JetFlavor, float JetPt, fl
 
 }
 
-bool BTagSFUtil::IsTagged(float JetDiscriminant, int JetFlavor, float JetPt, float JetEta) {
+bool BTagSFUtil::IsTagged(float JetDiscriminant, int JetFlavor, float JetPt, float JetEta, UInt_t Seed) {
   bool isBTagged = JetDiscriminant>TaggerCut;
   if (JetFlavor==-999999) return isBTagged; // Data: no correction needed
   bool newBTag = isBTagged;
@@ -168,6 +156,7 @@ bool BTagSFUtil::IsTagged(float JetDiscriminant, int JetFlavor, float JetPt, flo
   if (Btag_SF == 1) return newBTag; //no correction needed 
 
   //throw die
+  rand_ = new TRandom3(Seed); // Fixed seeds, dependent on event number, jet pT and systematic variation, for reproducibility. Use Seed=0 for testing that seed dependence is negligible.
   float coin = rand_->Uniform(1.);    
  
   if(Btag_SF > 1){  // use this if SF>1
@@ -190,6 +179,7 @@ bool BTagSFUtil::IsTagged(float JetDiscriminant, int JetFlavor, float JetPt, flo
 
   }
 
+  delete rand_;
   return newBTag;
 
 }

--- a/packages/BTagSFUtil/BTagSFUtil.C
+++ b/packages/BTagSFUtil/BTagSFUtil.C
@@ -156,6 +156,7 @@ bool BTagSFUtil::IsTagged(float JetDiscriminant, int JetFlavor, float JetPt, flo
   if (Btag_SF == 1) return newBTag; //no correction needed 
 
   //throw die
+  //Seed = 0; // Uncomment for using random seed.
   rand_ = new TRandom3(Seed); // Fixed seeds, dependent on event number, jet pT and systematic variation, for reproducibility. Use Seed=0 for testing that seed dependence is negligible.
   float coin = rand_->Uniform(1.);    
  

--- a/packages/BTagSFUtil/BTagSFUtil.h
+++ b/packages/BTagSFUtil/BTagSFUtil.h
@@ -11,11 +11,11 @@ class BTagSFUtil{
 
  public:
     
-  BTagSFUtil(string MeasurementType, string BTagAlgorithm, TString OperatingPoint, int SystematicIndex = 0, TString FastSimDataset = "", int Seed = 0);
+  BTagSFUtil(string MeasurementType, string BTagAlgorithm, TString OperatingPoint, int SystematicIndex = 0, TString FastSimDataset = "");
   ~BTagSFUtil();
 
   float GetJetSF(float JetDiscriminant, int JetFlavor, float JetPt, float JetEta);
-  bool IsTagged(float JetDiscriminant, int JetFlavor, float JetPt, float JetEta);
+  bool IsTagged(float JetDiscriminant, int JetFlavor, float JetPt, float JetEta, UInt_t Seed = 0);
 
  private:
 

--- a/packages/BTagSFUtil/README.txt
+++ b/packages/BTagSFUtil/README.txt
@@ -5,14 +5,14 @@ Class Usage:
  - BTagSFUtil *BTagSF = new BTagSFUtil(MeasurementType, BTagAlgorithm, OperatingPoint, SystematicIndex);
    
       Where: MeasurementType is the type of measurement you want to use:
-                             "mujets" -> combined b-jets SFs from methods based on QCD samples
-                             "comb"   -> combined b-jets SFs from QCD and ttbar datasets
-                             "comb"   -> SFs for light jets
-             BTagAlgorithm is the btag algorithm you want to use, ex: "CSV"
+                             "mujets" -> combined b-jets SFs from methods based on QCD samples, recommended for dileptonic ttbar precision measurements
+                             "comb"   -> combined b-jets SFs from QCD and ttbar datasets, generally recommended for b/c-jets except for the case above
+                             "incl"   -> SFs for light jets
+             BTagAlgorithm is the btag algorithm you want to use, ex: "CSVv2"
              OperatingPoint can be "Loose", "Medium" or "Tight"
              SystematicIndex +1 (-1) to scale up (down) the b-jets SF according to they total uncertainty
                              +3 (-3) to scale up (down) the light-jets SF according to they total uncertainty
-                             Remember that these two uncertainties have to be treated as independet!
+                             Remember that these two uncertainties have to be treated as independent!
 
  - When running over FastSim MC, the dataset has to be specified to retrive special correction factors:
   
@@ -21,18 +21,19 @@ Class Usage:
          Where the supported FastSim datasets for 8 TeV are T1bbbb, T1tttt, T2, T2bb, T2bwm T2tt and T3w
          SystematicIndex for FastSim SFs follow the same code as above +/-10 
 	     e.g. to scale down the FastSim SF for light-jets by its uncertainty, set SystematicIndex to -13
-             Note that for FastSim indepenent SFs for c-jets are used, with SystematicIndex +/-12
+             Note that for FastSim independent SFs for c-jets are used, with SystematicIndex +/-12
              Important: FastSim SF uncertainties should be treated as independet from standard SF ones
    
  - To get the SF for a given jet:
 
-      GetJetSF->IsTagged(JetFlavor, JetPt, JetEta);
+      GetJetSF(JetDiscriminant, JetFlavor, JetPt, JetEta);
 
  - For applying the SF to a jet according to the "flip a coin" method:
 
-      BTagSF->IsTagged(DiscriminatorValue, JetFlavor, JetPt, JetEta);
+      IsTagged(JetDiscriminant, JetFlavor, JetPt, JetEta, Seed)
 
-         Where: DiscriminatorValue is the value for the discriminant of your choise for the jet to which the SF has being applied
+         Where: JetDiscriminant is the value for the discriminant of your choice for the jet to which the SF has being applied
+         Seed initializes the random number generator for each jet. It is currently fixed as [event number] + [jet pT] + [systematic variation index] for reproducibility.
  
       Important note: this method to apply the SFs is designed in order to make a minimal use of absolute b-tag efficiencies. Nevertheless, 
       when the SFs are larger than 1, those efficiencies must be computed in the very MC samples on which the SFs have being applied. The 

--- a/packages/EventBuilder/EventBuilder.h
+++ b/packages/EventBuilder/EventBuilder.h
@@ -13,7 +13,7 @@ class EventBuilder : public PAFChainItemSelector{
     std::vector<Float_t> LHEWeights;
 
     EventBuilder();
-    virtual ~EventBuilder(){}
+    virtual ~EventBuilder() {delete fPUWeight, fPUWeightUp, fPUWeightDown, TriggSF;}
     virtual void InsideLoop();
     virtual void Initialise();
     virtual void Summary();

--- a/packages/JetSelector/JetSelector.C
+++ b/packages/JetSelector/JetSelector.C
@@ -157,7 +157,7 @@ void JetSelector::InsideLoop(){
 	  if(tJ.isBtag) nBtagJets++; 
 	} 
       }
-      if (tJ.p.Pt() > vetoJet_minPt && tJ.p.Eta() < vetoJet_maxEta){
+      if (tJ.p.Pt() > vetoJet_minPt && TMath::Abs(tJ.p.Eta()) < vetoJet_maxEta){
 	if (gSelection == iWWSelec && tJ.isBtag) vetoJets.push_back(tJ);
 	else if (gSelection == iTWSelec)          vetoJets.push_back(tJ);
 	else                                      vetoJets.push_back(tJ);
@@ -180,7 +180,7 @@ void JetSelector::InsideLoop(){
 	    if(tJ.isBtag) nBtagJets++;
 	  }
         }
-	if (tJ.p.Pt() > vetoJet_minPt && tJ.p.Eta() < vetoJet_maxEta){
+	if (tJ.p.Pt() > vetoJet_minPt && TMath::Abs(tJ.p.Eta()) < vetoJet_maxEta){
 	  if (gSelection == iWWSelec && tJ.isBtag) vetoJets.push_back(tJ);
 	  else if (gSelection == iTWSelec)          vetoJets.push_back(tJ);
 	  else                                      vetoJets.push_back(tJ);

--- a/packages/JetSelector/JetSelector.C
+++ b/packages/JetSelector/JetSelector.C
@@ -158,9 +158,9 @@ void JetSelector::InsideLoop(){
 	} 
       }
       if (tJ.p.Pt() > vetoJet_minPt && TMath::Abs(tJ.p.Eta()) < vetoJet_maxEta){
-	if (gSelection == iWWSelec && tJ.isBtag) vetoJets.push_back(tJ);
-	else if (gSelection == iTWSelec)          vetoJets.push_back(tJ);
-	else                                      vetoJets.push_back(tJ);
+	if (gSelection == iWWSelec){if (tJ.isBtag) vetoJets.push_back(tJ);}
+	else if (gSelection == iTWSelec)           vetoJets.push_back(tJ);
+	else                                       vetoJets.push_back(tJ);
       }
     }
   }
@@ -181,9 +181,9 @@ void JetSelector::InsideLoop(){
 	  }
         }
 	if (tJ.p.Pt() > vetoJet_minPt && TMath::Abs(tJ.p.Eta()) < vetoJet_maxEta){
-	  if (gSelection == iWWSelec && tJ.isBtag) vetoJets.push_back(tJ);
-	  else if (gSelection == iTWSelec)          vetoJets.push_back(tJ);
-	  else                                      vetoJets.push_back(tJ);
+	  if (gSelection == iWWSelec){if (tJ.isBtag) vetoJets.push_back(tJ);}
+	  else if (gSelection == iTWSelec)           vetoJets.push_back(tJ);
+	  else                                       vetoJets.push_back(tJ);
 	}
       }
     }

--- a/packages/JetSelector/JetSelector.C
+++ b/packages/JetSelector/JetSelector.C
@@ -199,7 +199,7 @@ void JetSelector::InsideLoop(){
           if(tJ.p.Pt() > 15 || tJ.pTJESUp > 15 || tJ.pTJESDown > 15) Jets15.push_back(tJ);
           if(tJ.p.Pt() > jet_MinPt) selJets.push_back(tJ);
         }
-	if (tJ.p.Pt() > vetoJet_minPt && TMath::Abs(tJ.p.Eta()) < vetoJet_maxEta) vetoJets.push_back(tJ);
+	 if (tJ.p.Pt() > vetoJet_minPt && TMath::Abs(tJ.p.Eta()) < vetoJet_maxEta) vetoJets.push_back(tJ);
       }
     }
   }

--- a/packages/JetSelector/JetSelector.C
+++ b/packages/JetSelector/JetSelector.C
@@ -138,10 +138,12 @@ void JetSelector::InsideLoop(){
   Leptons.clear();
   Leptons    = GetParam<vector<Lepton>>("selLeptons"); 
 
+  evt = (UInt_t)Get<ULong64_t>("evt");
+
   // Loop over the jets
   nJet = Get<Int_t>("nJet");
   for(Int_t i = 0; i < nJet; i++){
-    GetJetVariables(i);
+    GetJetVariables(i); cout << "Jet number " << i << " :   ";
     tJ = Jet(tpJ, csv, jetId, flavmc);
     tJ.isBtag = IsBtag(tJ);
     // Fill the vectors
@@ -224,9 +226,9 @@ void JetSelector::InsideLoop(){
 
 Bool_t JetSelector::IsBtag(Jet j){
   Bool_t isbtag;
-  if(gIsData) isbtag = fBTagSFnom->IsTagged(j.csv, -999999, j.p.Pt(), j.p.Eta());
+  if(gIsData) isbtag = fBTagSFnom->IsTagged(j.csv, -999999, j.p.Pt(), j.p.Eta(), evt+(UInt_t)j.p.Pt());
   else if(stringWP == "Loose") isbtag = Get<Float_t>("Jet_csv");//fBTagSFnom->IsTagged(j.csv, -999999, j.p.Pt(), j.p.Eta());
-  else        isbtag = fBTagSFnom->IsTagged(j.csv,j.flavmc, j.p.Pt(), j.p.Eta());
+  else        isbtag = fBTagSFnom->IsTagged(j.csv,j.flavmc, j.p.Pt(), j.p.Eta(), evt+(UInt_t)j.p.Pt());
   return isbtag;
 }
 
@@ -237,10 +239,10 @@ void JetSelector::SetSystematics(Jet *j){
   j->pTJESDown   = rawPt*pt_corrDown;
   j->pTJERUp     = _pt;
   j->pTJERDown   = _pt;
-  j->isBtag_BtagUp      = fBTagSFbUp->IsTagged(_csv, _flavmc, _pt, _eta);
-  j->isBtag_BtagDown    = fBTagSFbDo->IsTagged(_csv, _flavmc, _pt, _eta);
-  j->isBtag_MisTagUp    = fBTagSFlUp->IsTagged(_csv, _flavmc, _pt, _eta);
-  j->isBtag_MisTagDown  = fBTagSFlDo->IsTagged(_csv, _flavmc, _pt, _eta);
+  j->isBtag_BtagUp      = fBTagSFbUp->IsTagged(_csv, _flavmc, _pt, _eta, evt+(UInt_t)_pt+1);
+  j->isBtag_BtagDown    = fBTagSFbDo->IsTagged(_csv, _flavmc, _pt, _eta, evt+(UInt_t)_pt-1);
+  j->isBtag_MisTagUp    = fBTagSFlUp->IsTagged(_csv, _flavmc, _pt, _eta, evt+(UInt_t)_pt+3);
+  j->isBtag_MisTagDown  = fBTagSFlDo->IsTagged(_csv, _flavmc, _pt, _eta, evt+(UInt_t)_pt-3);
 }
 
 Bool_t JetSelector::Cleaning(Jet j, vector<Lepton> vLep, Float_t minDR){

--- a/packages/JetSelector/JetSelector.C
+++ b/packages/JetSelector/JetSelector.C
@@ -143,7 +143,7 @@ void JetSelector::InsideLoop(){
   // Loop over the jets
   nJet = Get<Int_t>("nJet");
   for(Int_t i = 0; i < nJet; i++){
-    GetJetVariables(i); cout << "Jet number " << i << " :   ";
+    GetJetVariables(i);
     tJ = Jet(tpJ, csv, jetId, flavmc);
     tJ.isBtag = IsBtag(tJ);
     // Fill the vectors

--- a/packages/JetSelector/JetSelector.h
+++ b/packages/JetSelector/JetSelector.h
@@ -14,7 +14,7 @@ class JetSelector : public PAFChainItemSelector{
   public:
     TString stringWP;
     JetSelector();
-    virtual ~JetSelector() {delete fBTagSFnom, fBTagSFbUp, fBTagSFbDo, fBTagSFlUp, fBTagSFlDo;};
+    virtual ~JetSelector() {delete fBTagSFnom, fBTagSFbUp, fBTagSFbDo, fBTagSFlUp, fBTagSFlDo;}
     virtual void InsideLoop();
     void Initialise();
     void Summary();

--- a/packages/JetSelector/JetSelector.h
+++ b/packages/JetSelector/JetSelector.h
@@ -48,7 +48,9 @@ class JetSelector : public PAFChainItemSelector{
     BTagSFUtil *fBTagSFbDo ;
     BTagSFUtil *fBTagSFlUp ;
     BTagSFUtil *fBTagSFlDo ;
+
     string MeasType;
+    UInt_t evt;
 
     Bool_t gIsData;
     Int_t gSelection;

--- a/packages/JetSelector/JetSelector.h
+++ b/packages/JetSelector/JetSelector.h
@@ -14,7 +14,7 @@ class JetSelector : public PAFChainItemSelector{
   public:
     TString stringWP;
     JetSelector();
-    virtual ~JetSelector() {}
+    virtual ~JetSelector() {delete fBTagSFnom, fBTagSFbUp, fBTagSFbDo, fBTagSFlUp, fBTagSFlDo;};
     virtual void InsideLoop();
     void Initialise();
     void Summary();

--- a/packages/LeptonSelector/LeptonSelector.h
+++ b/packages/LeptonSelector/LeptonSelector.h
@@ -13,7 +13,7 @@ class LeptonSelector : public PAFChainItemSelector{
   public:
 
     LeptonSelector(); 
-    virtual ~LeptonSelector() {}
+    virtual ~LeptonSelector() {delete LepSF;}
     virtual void InsideLoop();
     virtual void Initialise();
     virtual void Summary();

--- a/packages/PUWeight/PUWeight.C
+++ b/packages/PUWeight/PUWeight.C
@@ -896,6 +896,6 @@ TH3D* PUWeight::CalculateWeight3D(float ScaleFactor) {
   /////////////
 
 
-
+  delete DHist, MHist;
   return fWeight3D;
 }


### PR DESCRIPTION
Quoting https://twiki.cern.ch/twiki/bin/viewauth/CMS/BTagSFMethods#2a_Jet_by_jet_updating_of_the_b :
"One important aspect of this method is reproducibility and it is therefore important to always initialize the random number generator with the same random seed in the same event, irrespective of the order in which the events are processed."

Seed is now [event number] + [jet pT] + [bTagSF systematic variation index]. It can be reverted to random by uncommenting just one line. With this, the results are always the same every time MiniTrees are produced.


Some fixes in JetSelector loop, ensuring correct treatment of vetoJets. Main effect is on WW analysis.


Several deletes have been included for extra safety. Probably 0 effect but cannot hurt.