### PR TITLE
Correction BTagFSUtils for PoD

### DIFF
--- a/RunAnalyserPAF.C
+++ b/RunAnalyserPAF.C
@@ -208,12 +208,21 @@ void RunAnalyserPAF(TString sampleName, TString Selection, Int_t nSlots, Long64_
   }
 
 
-  // PAF mode
+  // PAF mode selection (based on number of slots)
   //----------------------------------------------------------------------------
   PAFIExecutionEnvironment* pafmode = 0;
-  if      (nSlots <=1 ) pafmode = new PAFSequentialEnvironment();
-  else if (nSlots <=64) pafmode = new PAFPROOFLiteEnvironment(nSlots);
-  else                  pafmode = new PAFPoDEnvironment(nSlots);
+  if      (nSlots <=1 ) {
+    PAF_INFO("RunAnalyser", "Sequential mode selected");
+    pafmode = new PAFSequentialEnvironment();
+  }
+  else if (nSlots <=8 ) {
+    PAF_INFO("RunAnalyser", "PROOF Lite mode selected");
+    pafmode = new PAFPROOFLiteEnvironment(nSlots);
+  }
+  else {
+    PAF_INFO("RunAnalyser", "PoD mode selected");
+    pafmode = new PAFPoDEnvironment(nSlots);
+  }
   PAFProject* myProject = new PAFProject(pafmode); // Create PAF Project whith that environment
 
   myProject->AddLibrary("/nfs/fanae/root6/lib/libTMVA.so");
@@ -249,6 +258,10 @@ void RunAnalyserPAF(TString sampleName, TString Selection, Int_t nSlots, Long64_
 	myProject->SetInputParam("lspMass"      , lspMass          );
 	myProject->SetInputParam("doSyst"       , G_DoSystematics  ); 
 
+
+	// CONFIGURATION PARAMETERS
+	myProject->SetInputParam("BTagSFPath", 
+				 TString(Form("%s/packages/BTagSFUtil/", gSystem->ExpandPathName("$PWD"))));
 
 	// Name of analysis class
 	//----------------------------------------------------------------------------

--- a/packages/BTagSFUtil/BTagSFUtil.C
+++ b/packages/BTagSFUtil/BTagSFUtil.C
@@ -9,13 +9,17 @@
 
 using namespace std;
 
-BTagSFUtil::BTagSFUtil(string MeasurementType, string BTagAlgorithm, TString OperatingPoint, int SystematicIndex, TString FastSimDataset) {
+BTagSFUtil::BTagSFUtil(const string& MeasurementType, 
+		       const TString& BTagSFPath, const string& BTagAlgorithm, 
+		       const TString& OperatingPoint, int SystematicIndex, TString FastSimDataset) {
 
   //rand_ = new TRandom3(Seed);
-
-  string CSVFileName = (string)gSystem->ExpandPathName("$PWD") + "/packages/BTagSFUtil/" + BTagAlgorithm + ".csv";
-  const BTagCalibration calib(BTagAlgorithm, CSVFileName);
-
+  TString CSVFileName = Form("%s/%s.csv", BTagSFPath.Data(), BTagAlgorithm.c_str());
+  //  string CSVFileName = (string) pathtocsv.Data() + BTagAlgorithm + ".csv";
+  cout << "PAF_INFO: [BTagSFUtil] BTag SF will be read from " << CSVFileName << endl;
+  
+  const BTagCalibration calib(BTagAlgorithm, (string) CSVFileName.Data());
+  
   SystematicFlagBC = "central";
   SystematicFlagL  = "central";
   if (abs(SystematicIndex)<10) {

--- a/packages/BTagSFUtil/BTagSFUtil.h
+++ b/packages/BTagSFUtil/BTagSFUtil.h
@@ -11,7 +11,9 @@ class BTagSFUtil{
 
  public:
     
-  BTagSFUtil(string MeasurementType, string BTagAlgorithm, TString OperatingPoint, int SystematicIndex = 0, TString FastSimDataset = "");
+  BTagSFUtil(const string& MeasurementType, 
+	     const TString& BTagSFPath, const string& BTagAlgorithm, 
+	     const TString& OperatingPoint, int SystematicIndex = 0, TString FastSimDataset = "");
   ~BTagSFUtil();
 
   float GetJetSF(float JetDiscriminant, int JetFlavor, float JetPt, float JetEta);

--- a/packages/JetSelector/JetSelector.C
+++ b/packages/JetSelector/JetSelector.C
@@ -91,11 +91,13 @@ void JetSelector::Initialise(){
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
   if (gSelection == iTopSelec) MeasType = "mujets";
-  fBTagSFnom = new BTagSFUtil(MeasType, "CSVv2", stringWP,  0);
-  fBTagSFbUp = new BTagSFUtil(MeasType, "CSVv2", stringWP,  1);
-  fBTagSFbDo = new BTagSFUtil(MeasType, "CSVv2", stringWP, -1);
-  fBTagSFlUp = new BTagSFUtil(MeasType, "CSVv2", stringWP,  3);
-  fBTagSFlDo = new BTagSFUtil(MeasType, "CSVv2", stringWP, -3);
+  TString BTagSFPath  = GetParam<TString>("BTagSFPath");
+
+  fBTagSFnom = new BTagSFUtil(MeasType, BTagSFPath, "CSVv2", stringWP,  0);
+  fBTagSFbUp = new BTagSFUtil(MeasType, BTagSFPath, "CSVv2", stringWP,  1);
+  fBTagSFbDo = new BTagSFUtil(MeasType, BTagSFPath, "CSVv2", stringWP, -1);
+  fBTagSFlUp = new BTagSFUtil(MeasType, BTagSFPath, "CSVv2", stringWP,  3);
+  fBTagSFlDo = new BTagSFUtil(MeasType, BTagSFPath, "CSVv2", stringWP, -3);
 
   Leptons  = std::vector<Lepton>();
   selJets  = std::vector<Jet>();


### PR DESCRIPTION
PoD uses its own sandbox to run. So finding out absolute paths at the slaves will show different values from what is expected at the master. This is solved by passing around a new input parameter which host the absolute path to the BTagSFUtils package location where the CSV files are located.