### PR TITLE
Reuse input parameter for BTagSFUtils

### DIFF
--- a/RunAnalyserPAF.C
+++ b/RunAnalyserPAF.C
@@ -259,10 +259,6 @@ void RunAnalyserPAF(TString sampleName, TString Selection, Int_t nSlots, Long64_
 	myProject->SetInputParam("doSyst"       , G_DoSystematics  ); 
 
 
-	// CONFIGURATION PARAMETERS
-	myProject->SetInputParam("BTagSFPath", 
-				 TString(Form("%s/packages/BTagSFUtil/", gSystem->ExpandPathName("$PWD"))));
-
 	// Name of analysis class
 	//----------------------------------------------------------------------------
 	myProject->AddSelectorPackage("LeptonSelector");

--- a/packages/JetSelector/JetSelector.C
+++ b/packages/JetSelector/JetSelector.C
@@ -27,6 +27,15 @@ JetSelector::JetSelector() : PAFChainItemSelector() {
   jet_MinPt = 0;
   vetoJet_minPt = 0;
 }
+
+JetSelector::~JetSelector() {
+  delete fBTagSFnom; 
+  delete fBTagSFbUp; 
+  delete fBTagSFbDo;
+  delete fBTagSFlUp; 
+  delete fBTagSFlDo;
+}
+
 void JetSelector::Summary(){}
 
 void JetSelector::Initialise(){
@@ -91,7 +100,9 @@ void JetSelector::Initialise(){
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
   if (gSelection == iTopSelec) MeasType = "mujets";
-  TString BTagSFPath  = GetParam<TString>("BTagSFPath");
+  TString pwd  = GetParam<TString>("WorkingDir");
+  TString BTagSFPath = Form("%s/packages/BTagSFUtil", pwd.Data());
+  
 
   fBTagSFnom = new BTagSFUtil(MeasType, BTagSFPath, "CSVv2", stringWP,  0);
   fBTagSFbUp = new BTagSFUtil(MeasType, BTagSFPath, "CSVv2", stringWP,  1);
@@ -110,7 +121,7 @@ void JetSelector::Initialise(){
 
 }
 
-void JetSelector::GetJetVariables(Int_t i, TString jec){
+void JetSelector::GetJetVariables(Int_t i, const TString& jec){
   tpJ.SetPxPyPzE(Get<Float_t>("Jet"+jec+"_px",i), Get<Float_t>("Jet"+jec+"_py",i), Get<Float_t>("Jet"+jec+"_pz", i), Get<Float_t>("Jet"+jec+"_energy",i));
   eta = tpJ.Eta();;
   pt = tpJ.Pt();
@@ -164,7 +175,7 @@ void JetSelector::GetGenJetVariables(Int_t i){
   pt =  Get<Float_t>("genJet_pt",i);
 }
 
-void JetSelector::GetmcJetVariables(Int_t i, TString jec){
+void JetSelector::GetmcJetVariables(Int_t i, const TString& jec){
   tpJ.SetPxPyPzE(Get<Float_t>("Jet"+jec+"_mcPx",i), Get<Float_t>("Jet"+jec+"_mcPy",i), Get<Float_t>("Jet"+jec+"_mcPz", i), Get<Float_t>("Jet"+jec+"_mcEnergy",i));
   eta = tpJ.Eta();
   pt =  Get<Float_t>("Jet"+jec+"_mcPt",i);

--- a/packages/JetSelector/JetSelector.h
+++ b/packages/JetSelector/JetSelector.h
@@ -14,7 +14,7 @@ class JetSelector : public PAFChainItemSelector{
   public:
     TString stringWP;
     JetSelector();
-    virtual ~JetSelector() {delete fBTagSFnom, fBTagSFbUp, fBTagSFbDo, fBTagSFlUp, fBTagSFlDo;}
+    virtual ~JetSelector();
     virtual void InsideLoop();
     void Initialise();
     void Summary();
@@ -75,10 +75,10 @@ class JetSelector : public PAFChainItemSelector{
     Int_t ngenJet;
 
     void GetDiscJetVariables(Int_t i);
-    void GetJetVariables(Int_t i, TString jec = "");
+    void GetJetVariables(Int_t i, const TString& jec = "");
     void GetJetFwdVariables(Int_t i);
     void GetGenJetVariables(Int_t i);
-    void GetmcJetVariables(Int_t i, TString jec = "");
+    void GetmcJetVariables(Int_t i, const TString& jec = "");
     Bool_t IsBtag(Jet j); 
     void SetSystematics(Jet *j);
     Bool_t Cleaning(Jet j, vector<Lepton> vLep, Float_t minDR = 0.4);


### PR DESCRIPTION
As pointed by Xuan (part of) the path was already passed as an input parameter, so I have refactored that. I also corrected a couple of other things in JetSelector that should improve efficiency and memory management.