### PR TITLE
WZ Code

### DIFF
--- a/RunAnalyserPAF.C
+++ b/RunAnalyserPAF.C
@@ -118,6 +118,7 @@ void RunAnalyserPAF(TString sampleName, TString Selection, Int_t nSlots,
   else if(Selection == "StopTop"   || Selection == "topSUSY" ) sel = iStopTopSelec;
   else if(Selection == "WW"                                  ) sel = iWWSelec;
   else if(Selection == "HWW"                                 ) sel = iHWWSelec;
+  else if(Selection == "WZ"                                  ) sel = iWZSelec;
   else { 
     PAF_ERROR("RunAnalyserPAF", Form("Wrong selection \"%s\".",
 				     Selection.Data()));
@@ -376,6 +377,7 @@ void RunAnalyserPAF(TString sampleName, TString Selection, Int_t nSlots,
   }
   else if (sel == iWWSelec  )  myProject->AddSelectorPackage("WWAnalysis");
   else if (sel == iHWWSelec )  myProject->AddSelectorPackage("HWWAnalysis");
+  else if (sel == iWZSelec  )  myProject->AddSelectorPackage("WZAnalysis");
   else                         PAF_FATAL("RunAnalyserPAF", "No selector defined for this analysis!!!!");
   
   // Additional packages

--- a/packages/Functions/Functions.C
+++ b/packages/Functions/Functions.C
@@ -555,3 +555,37 @@ void DumpEvent(Int_t evt, TString s, Bool_t verbose){
     if(evt == ee) cout << s << endl;
   }
 }
+
+std::vector<Lepton> AssignWZLeptons(std::vector<Lepton> leptonList){//Assign W and Z Leptons as in the WZ analysis. Z leptons are assigned to the best invariant mass pair, W lepton is the next higher p_T lepton.
+  Float_t dZmass = 100000.; 
+  Int_t nLeptons = leptonList.size();
+  Int_t indexZ1;
+  Int_t indexZ2;
+  std::vector<Lepton> WZleps;
+  for(Int_t i = 0; i < nLeptons; i++){
+    for(Int_t j = i+1; j < nLeptons; j++){
+      if ( ( (leptonList.at(j).isMuon && leptonList.at(i).isMuon) || (leptonList.at(j).isElec && leptonList.at(i).isElec)    ) && leptonList.at(i).charge*leptonList.at(j).charge == -1){
+        Float_t hypZmass = (leptonList.at(j).p + leptonList.at(i).p).M();
+        if (TMath::Abs(hypZmass-91.1876) < dZmass){
+          dZmass = TMath::Abs(hypZmass-91.1876);
+          indexZ1 = j;
+          indexZ2 = i;
+          if (leptonList.at(j).Pt() > leptonList.at(i).Pt()) {
+            WZleps.push_back(leptonList.at(j));
+            WZleps.push_back(leptonList.at(i));
+          }
+          else{
+            WZleps.push_back(leptonList.at(i));
+            WZleps.push_back(leptonList.at(j));
+          }
+        }
+      }
+    }
+  }
+  for(Int_t i = 0; i < nLeptons; i++){
+    if (i != indexZ1 && i != indexZ2){
+      WZleps.push_back(leptonList.at(i));
+    }
+  }  
+  return WZleps;
+}

--- a/packages/Functions/Functions.h
+++ b/packages/Functions/Functions.h
@@ -95,7 +95,6 @@ Bool_t IsThere3SS(vector<Lepton> lepton);
 Bool_t ByPt(Jet, Jet);
 std::vector<Lepton> AssignWZLeptons(std::vector<Lepton> leptonList);
 
-
 Int_t   getCS(vector<Lepton> lepton);
 void co(TString out, TString co);
 void DumpVar(Int_t evt, TString varname, Float_t val, Bool_t pass = false, Bool_t verbose = false);

--- a/packages/Functions/Functions.h
+++ b/packages/Functions/Functions.h
@@ -93,6 +93,8 @@ Float_t ClosestMlltoZ(vector<Lepton> leptons);
 Bool_t IsThereSSpair(vector<Lepton> leptons);
 Bool_t IsThere3SS(vector<Lepton> lepton);
 Bool_t ByPt(Jet, Jet);
+std::vector<Lepton> AssignWZLeptons(std::vector<Lepton> leptonList);
+
 
 Int_t   getCS(vector<Lepton> lepton);
 void co(TString out, TString co);

--- a/packages/Functions/Functions.h
+++ b/packages/Functions/Functions.h
@@ -94,7 +94,7 @@ Bool_t IsThereSSpair(vector<Lepton> leptons);
 Bool_t IsThere3SS(vector<Lepton> lepton);
 Bool_t ByPt(Jet, Jet);
 Int_t GetDileptonicChannel(vector<Lepton> leptons);
-std::vector<Lepton> AssignWZLeptons(std::vector<Lepton> leptonList);
+vector<Lepton> AssignWZLeptons(vector<Lepton> leptonList);
 
 Int_t   getCS(vector<Lepton> lepton);
 void co(TString out, TString co);

--- a/packages/JetSelector/JetSelector.C
+++ b/packages/JetSelector/JetSelector.C
@@ -94,7 +94,7 @@ void JetSelector::Initialise(){
   }
   else if(gSelection == iWZSelec){
     taggerName="CSVv2";
-    stringWP = "Loose";
+    stringWP = "Medium";
     jet_MaxEta = 2.4;
     jet_MinPt  = 30;
     vetoJet_minPt = 20;

--- a/packages/LeptonSelector/LeptonSelector.C
+++ b/packages/LeptonSelector/LeptonSelector.C
@@ -367,44 +367,44 @@ Bool_t LeptonSelector::getMultiIso(Int_t wp){
 Int_t LeptonSelector::getSUSYMVAId(Lepton lep, Int_t ty){//ty = 1 for FO, ty = 2 for tight
 	if (ty == 1){//Fakeable Objects
 		if (lep.isMuon){
-				if (ptRatio > 0.30 && jetBTagCSV < 0.3) return 6; //Only for FO
-				else if (MVASUSY >  0.65) return 6; //Extra Tight
-				else if (MVASUSY >  0.45) return 5; //Very Tight
-				else if (MVASUSY >  0.15) return 4; //Tight
-				else if (MVASUSY > -0.20) return 3; //Medium
-				else if (MVASUSY > -0.60) return 2; //Loose
-				else if (MVASUSY > -0.90) return 1; //Very Loose
+				if (ptRatio > 0.30 && jetBTagCSV < 0.3) return 7; //Only for FO
+				else if (MVASUSY >  0.65) return 7; //Extra Tight
+				else if (MVASUSY >  0.45) return 6; //Very Tight
+				else if (MVASUSY >  0.15) return 5; //Tight
+				else if (MVASUSY > -0.20) return 4; //Medium
+				else if (MVASUSY > -0.60) return 3; //Loose
+				else if (MVASUSY > -0.90) return 2; //Very Loose
 		}
 		else if (lep.isElec){
-				if (ptRatio > 0.30 && jetBTagCSV < 0.3 && ( (MVAID > 0.0)*(lep.p.Eta() < 0.8) || (MVAID > 0.0)*(lep.p.Eta() < 1.479)*(lep.p.Eta() > 0.8) || (MVAID > 0.3)*(lep.p.Eta() > 1.479) )) return 6; //Only for FO
-				else if (MVASUSY >  0.85) return 6; //Extra Tight
-				else if (MVASUSY >  0.75) return 5; //Very Tight
-				else if (MVASUSY >  0.65) return 4; //Tight
-				else if (MVASUSY >  0.50) return 3; //Medium
-				else if (MVASUSY >  0.25) return 2; //Loose
-				else if (MVASUSY > -0.30) return 1; //Very Loose
+				if (ptRatio > 0.30 && jetBTagCSV < 0.3 && ( (MVAID > 0.0)*(lep.p.Eta() < 0.8) || (MVAID > 0.0)*(lep.p.Eta() < 1.479)*(lep.p.Eta() > 0.8) || (MVAID > 0.3)*(lep.p.Eta() > 1.479) )) return 7; //Only for FO
+				else if (MVASUSY >  0.85) return 7; //Extra Tight
+				else if (MVASUSY >  0.75) return 6; //Very Tight
+				else if (MVASUSY >  0.65) return 5; //Tight
+				else if (MVASUSY >  0.50) return 4; //Medium
+				else if (MVASUSY >  0.25) return 3; //Loose
+				else if (MVASUSY > -0.30) return 2; //Very Loose
 		}
 	}
 
 	else if (ty == 2){//Tight leptonMVA leptons
 		if (lep.isMuon){
-				if      (MVASUSY >  0.65) return 6; //Extra Tight
-				else if (MVASUSY >  0.45) return 5; //Very Tight
-				else if (MVASUSY >  0.15) return 4; //Tight
-				else if (MVASUSY > -0.20) return 3; //Medium
-				else if (MVASUSY > -0.60) return 2; //Loose
-				else if (MVASUSY > -0.90) return 1; //Very Loose
+				if      (MVASUSY >  0.65) return 7; //Extra Tight
+				else if (MVASUSY >  0.45) return 6; //Very Tight
+				else if (MVASUSY >  0.15) return 5; //Tight
+				else if (MVASUSY > -0.20) return 4; //Medium
+				else if (MVASUSY > -0.60) return 3; //Loose
+				else if (MVASUSY > -0.90) return 2; //Very Loose
 		}
 		else if (lep.isElec){
-				if      (MVASUSY >  0.85) return 6; //Extra Tight
-				else if (MVASUSY >  0.75) return 5; //Very Tight
-				else if (MVASUSY >  0.65) return 4; //Tight
-				else if (MVASUSY >  0.50) return 3; //Medium
-				else if (MVASUSY >  0.25) return 2; //Loose
-				else if (MVASUSY > -0.30) return 1; //Very Loose
+				if      (MVASUSY >  0.85) return 7; //Extra Tight
+				else if (MVASUSY >  0.75) return 6; //Very Tight
+				else if (MVASUSY >  0.65) return 5; //Tight
+				else if (MVASUSY >  0.50) return 4; //Medium
+				else if (MVASUSY >  0.25) return 3; //Loose
+				else if (MVASUSY > -0.30) return 2; //Very Loose
 		}
 	}
-  return 0;
+  return 1;
 }
 
 //################################################################
@@ -511,21 +511,49 @@ Bool_t LeptonSelector::isGoodLepton(Lepton lep){
     return true;
   }
   else if(gSelection == iWZSelec){ // Fakeable Objects for the WZ analysis. MVA WP (and related selection criteria) are defined inside the proper analysis
-    if(lep.isMuon){
-			if(!isVetoLepton(lep)) return false;
-			if(TightCharge != 2) return false;
+		Bool_t isMVALepton = true;    
+		if(lep.isMuon){
+			if(!isVetoLepton(lep)) isMVALepton = false;
+			if(TightCharge != 2) isMVALepton = false;
 			// Added MVA selection in the analysis
-
     }
     if(lep.isElec){
-			if(!isVetoLepton(lep)) return false;
-			if(TightCharge != 2) return false;
-			if(!convVeto) return false;
+			if(!isVetoLepton(lep)) isMVALepton = false;
+			if(TightCharge != 2) isMVALepton = false;
+			if(!convVeto) isMVALepton = false;
 			// Added MVA selection in the analysis
     }
-		lepMVASUSYId = getSUSYMVAId(lep, 2);
-		if (lepMVASUSYId < 0) return false;
-    return true;
+
+		Bool_t isTopLepton = true;
+		//Top/Stop ID		
+		if(lep.isMuon){
+      passId  = getMuonId(iTight);
+      passIso = getRelIso04POG(iTight);
+    }
+    if(lep.isElec){
+      passId = getElecCutBasedId(iTight) && lostHits <= 1;
+      passIso = getRelIso03POG(iTight);
+      if(TMath::Abs(etaSC) > 1.4442 && TMath::Abs(etaSC) < 1.566) isTopLepton = false;
+    }
+    if(lep.p.Pt() < 20 || TMath::Abs(lep.p.Eta()) > 2.4) isTopLepton = false;
+    if(passId && passIso && ( (lep.isElec && getGoodVertex(iTight)) || (lep.isMuon && getGoodVertex(iMedium) ))){
+			isTopLepton = true;
+		}
+    else isTopLepton = false;
+
+		if (isTopLepton && isMVALepton){
+	    lepMVASUSYId = getSUSYMVAId(lep, 2) + 10; //This is a terrible but quick way to do it
+			return true;
+		}
+		else if (isTopLepton && !(isMVALepton)){
+	    lepMVASUSYId = 10; //This is a terrible but quick way to do it
+			return true;	
+		}
+		else if ( (!isTopLepton) && isMVALepton){
+	    lepMVASUSYId = getSUSYMVAId(lep, 2); //This is a terrible but quick way to do it
+			return true;		
+		}
+		else return false;
   }
   else if (gSelection == ittHSelec ) {
     // 	Tight muons for multilepton ttH Analysis:

--- a/packages/LeptonSelector/LeptonSelector.C
+++ b/packages/LeptonSelector/LeptonSelector.C
@@ -71,9 +71,9 @@ void LeptonSelector::Initialise(){
   else std::cout << ">>>>>>>>>>>> WRONG SELECTION!!!!!!!!" << std::endl;
   //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
-  selLeptons 	  = std::vector<Lepton>();
-  vetoLeptons 	= std::vector<Lepton>();
-  looseLeptons 	= std::vector<Lepton>();
+  selLeptons   = std::vector<Lepton>();
+  vetoLeptons   = std::vector<Lepton>();
+  looseLeptons   = std::vector<Lepton>();
 }
 
 //################################################################
@@ -140,7 +140,7 @@ Bool_t LeptonSelector::getRelIso04POG(Int_t wp){ // wps for muons
 
 Bool_t LeptonSelector::getminiRelIso(Int_t wp) {
   if (wp == iTight || wp == iMedium || wp == iLoose) {
-  	if (miniIso > 0.4) return false;
+    if (miniIso > 0.4) return false;
   }
   return true;
 }
@@ -210,31 +210,31 @@ Bool_t LeptonSelector::getElecMVA(Int_t wp){
 
 Bool_t LeptonSelector::getElecMVAId(Int_t wp, Lepton lep) {
   if (wp == iTight) {
-    Float_t	 A = -0.86+(-0.85 + 0.86)*(abs(eta) > 0.8)+(-0.81 + 0.86)*(abs(eta) > 1.479);
+    Float_t   A = -0.86+(-0.85 + 0.86)*(abs(eta) > 0.8)+(-0.81 + 0.86)*(abs(eta) > 1.479);
     Float_t  B = -0.96+(-0.96 + 0.96)*(abs(eta) > 0.8)+(-0.95 + 0.96)*(abs(eta) > 1.479);
     if (pt > 10) {
-	  	if (!(MVAID > min( A , max( B , A+(B-A)/10*(pt-15))) )) return false;
-		}
+      if (!(MVAID > min( A , max( B , A+(B-A)/10*(pt-15))) )) return false;
+    }
     if (abs(eta) < 0.8) {
-  	  if (sigmaIEtaIEta > 0.011) 						return false;
-  	  if (HoE > 0.10) 											return false;
-  	  if (dEtaSC > 0.01) 										return false;
-  	  if (dPhiSC > 0.04) 										return false;
-  	  if (eImpI < -0.05 || eImpI > 0.0010) 	return false;
+      if (sigmaIEtaIEta > 0.011)             return false;
+      if (HoE > 0.10)                       return false;
+      if (dEtaSC > 0.01)                     return false;
+      if (dPhiSC > 0.04)                     return false;
+      if (eImpI < -0.05 || eImpI > 0.0010)   return false;
     }
     else if ((abs(eta) < 1.479) && (abs(eta) >= 0.8)){
-  	  if (sigmaIEtaIEta > 0.011) 						return false;
-      if (HoE > 0.10) 											return false;
-      if (dEtaSC > 0.01) 										return false;
-      if (dPhiSC > 0.04) 										return false;
-      if (eImpI < -0.05 || eImpI > 0.0010) 	return false;
+      if (sigmaIEtaIEta > 0.011)             return false;
+      if (HoE > 0.10)                       return false;
+      if (dEtaSC > 0.01)                     return false;
+      if (dPhiSC > 0.04)                     return false;
+      if (eImpI < -0.05 || eImpI > 0.0010)   return false;
     }
     else if (abs(eta) >= 1.479) {
-  	  if (sigmaIEtaIEta > 0.030) 						return false;
-      if (HoE > 0.07)												return false;
-      if (dEtaSC > 0.008) 									return false;
-      if (dPhiSC > 0.07) 										return false;
-      if (eImpI < -0.05 || eImpI > 0.005) 	return false;
+      if (sigmaIEtaIEta > 0.030)             return false;
+      if (HoE > 0.07)                        return false;
+      if (dEtaSC > 0.008)                   return false;
+      if (dPhiSC > 0.07)                     return false;
+      if (eImpI < -0.05 || eImpI > 0.005)   return false;
     }
     if (convVeto == 0)     return false;
     if (lostHits != 0)     return false;
@@ -242,47 +242,47 @@ Bool_t LeptonSelector::getElecMVAId(Int_t wp, Lepton lep) {
 
   if (wp == iMedium) {
     if (isGoodLepton(lep)) {
-      Float_t	 A = -0.86+(-0.85 + 0.86)*(abs(eta) > 0.8)+(-0.81 + 0.86)*(abs(eta) > 1.479);
+      Float_t   A = -0.86+(-0.85 + 0.86)*(abs(eta) > 0.8)+(-0.81 + 0.86)*(abs(eta) > 1.479);
       Float_t  B = -0.96+(-0.96 + 0.96)*(abs(eta) > 0.8)+(-0.95 + 0.96)*(abs(eta) > 1.479);
       if (pt > 10) {
         if (!(MVAID > min( A , max( B , A+(B-A)/10*(pt-15))) )) return false;
       }
     }
-  	if (abs(eta) < 0.8) {
-  	  if (!isGoodLepton(lep)) {
-  	    if (MVAID < 0) 					  	           return false;
-  	  }
-  	  if (sigmaIEtaIEta > 0.011) 			       return false;
-  	  if (HoE > 0.10) 						           return false;
-  	  if (dEtaSC > 0.01) 					           return false;
-  	  if (dPhiSC > 0.04) 					           return false;
-  	  if (eImpI < -0.05 || eImpI > 0.0010) 	 return false;
+    if (abs(eta) < 0.8) {
+      if (!isGoodLepton(lep)) {
+        if (MVAID < 0)                          return false;
+      }
+      if (sigmaIEtaIEta > 0.011)              return false;
+      if (HoE > 0.10)                        return false;
+      if (dEtaSC > 0.01)                      return false;
+      if (dPhiSC > 0.04)                      return false;
+      if (eImpI < -0.05 || eImpI > 0.0010)    return false;
     }
     else if ((abs(eta) < 1.479) && (abs(eta) >= 0.8)) {
       if (!isGoodLepton(lep)) {
-        if (MVAID < 0) 					  	           return false;
+        if (MVAID < 0)                          return false;
       }
-      if (sigmaIEtaIEta > 0.011) 			       return false;
-      if (HoE > 0.10) 						           return false;
-      if (dEtaSC > 0.01) 					           return false;
-      if (dPhiSC > 0.04) 					           return false;
-      if (eImpI < -0.05 || eImpI > 0.0010) 	 return false;
+      if (sigmaIEtaIEta > 0.011)              return false;
+      if (HoE > 0.10)                        return false;
+      if (dEtaSC > 0.01)                      return false;
+      if (dPhiSC > 0.04)                      return false;
+      if (eImpI < -0.05 || eImpI > 0.0010)    return false;
     }
     else if (abs(eta) >= 1.479) {
       if (!isGoodLepton(lep)) {
-        if (MVAID < 0.7) 					             return false;
+        if (MVAID < 0.7)                        return false;
       }
-        if (sigmaIEtaIEta > 0.030) 			     return false;
-        if (HoE > 0.07)						           return false;
-        if (dEtaSC > 0.008) 					       return false;
-        if (dPhiSC > 0.07) 					         return false;
+        if (sigmaIEtaIEta > 0.030)            return false;
+        if (HoE > 0.07)                       return false;
+        if (dEtaSC > 0.008)                  return false;
+        if (dPhiSC > 0.07)                    return false;
         if (eImpI < -0.05 || eImpI > 0.005)  return false;
     }
     if (lostHits != 0)                     return false;
   }
 
   if (wp == iLoose) {
-    Float_t	 A = -0.86+(-0.85 + 0.86)*(abs(eta) > 0.8)+(-0.81 + 0.86)*(abs(eta) > 1.479);
+    Float_t   A = -0.86+(-0.85 + 0.86)*(abs(eta) > 0.8)+(-0.81 + 0.86)*(abs(eta) > 1.479);
     Float_t  B = -0.96+(-0.96 + 0.96)*(abs(eta) > 0.8)+(-0.95 + 0.96)*(abs(eta) > 1.479);
     if (pt > 10) {
       if (!(MVAID > min( A , max( B , A+(B-A)/10*(pt-15))) )) return false;
@@ -365,45 +365,45 @@ Bool_t LeptonSelector::getMultiIso(Int_t wp){
 
 
 Int_t LeptonSelector::getSUSYMVAId(Lepton lep, Int_t ty){//ty = 1 for FO, ty = 2 for tight
-	if (ty == 1){//Fakeable Objects
-		if (lep.isMuon){
-				if (ptRatio > 0.30 && jetBTagCSV < 0.3) return 7; //Only for FO
-				else if (MVASUSY >  0.65) return 7; //Extra Tight
-				else if (MVASUSY >  0.45) return 6; //Very Tight
-				else if (MVASUSY >  0.15) return 5; //Tight
-				else if (MVASUSY > -0.20) return 4; //Medium
-				else if (MVASUSY > -0.60) return 3; //Loose
-				else if (MVASUSY > -0.90) return 2; //Very Loose
-		}
-		else if (lep.isElec){
-				if (ptRatio > 0.30 && jetBTagCSV < 0.3 && ( (MVAID > 0.0)*(lep.p.Eta() < 0.8) || (MVAID > 0.0)*(lep.p.Eta() < 1.479)*(lep.p.Eta() > 0.8) || (MVAID > 0.3)*(lep.p.Eta() > 1.479) )) return 7; //Only for FO
-				else if (MVASUSY >  0.85) return 7; //Extra Tight
-				else if (MVASUSY >  0.75) return 6; //Very Tight
-				else if (MVASUSY >  0.65) return 5; //Tight
-				else if (MVASUSY >  0.50) return 4; //Medium
-				else if (MVASUSY >  0.25) return 3; //Loose
-				else if (MVASUSY > -0.30) return 2; //Very Loose
-		}
-	}
+  if (ty == 1){//Fakeable Objects
+    if (lep.isMuon){
+        if (ptRatio > 0.30 && jetBTagCSV < 0.3) return 7; //Only for FO
+        else if (MVASUSY >  0.65) return 7; //Extra Tight
+        else if (MVASUSY >  0.45) return 6; //Very Tight
+        else if (MVASUSY >  0.15) return 5; //Tight
+        else if (MVASUSY > -0.20) return 4; //Medium
+        else if (MVASUSY > -0.60) return 3; //Loose
+        else if (MVASUSY > -0.90) return 2; //Very Loose
+    }
+    else if (lep.isElec){
+        if (ptRatio > 0.30 && jetBTagCSV < 0.3 && ( (MVAID > 0.0)*(lep.p.Eta() < 0.8) || (MVAID > 0.0)*(lep.p.Eta() < 1.479)*(lep.p.Eta() > 0.8) || (MVAID > 0.3)*(lep.p.Eta() > 1.479) )) return 7; //Only for FO
+        else if (MVASUSY >  0.85) return 7; //Extra Tight
+        else if (MVASUSY >  0.75) return 6; //Very Tight
+        else if (MVASUSY >  0.65) return 5; //Tight
+        else if (MVASUSY >  0.50) return 4; //Medium
+        else if (MVASUSY >  0.25) return 3; //Loose
+        else if (MVASUSY > -0.30) return 2; //Very Loose
+    }
+  }
 
-	else if (ty == 2){//Tight leptonMVA leptons
-		if (lep.isMuon){
-				if      (MVASUSY >  0.65) return 7; //Extra Tight
-				else if (MVASUSY >  0.45) return 6; //Very Tight
-				else if (MVASUSY >  0.15) return 5; //Tight
-				else if (MVASUSY > -0.20) return 4; //Medium
-				else if (MVASUSY > -0.60) return 3; //Loose
-				else if (MVASUSY > -0.90) return 2; //Very Loose
-		}
-		else if (lep.isElec){
-				if      (MVASUSY >  0.85) return 7; //Extra Tight
-				else if (MVASUSY >  0.75) return 6; //Very Tight
-				else if (MVASUSY >  0.65) return 5; //Tight
-				else if (MVASUSY >  0.50) return 4; //Medium
-				else if (MVASUSY >  0.25) return 3; //Loose
-				else if (MVASUSY > -0.30) return 2; //Very Loose
-		}
-	}
+  else if (ty == 2){//Tight leptonMVA leptons
+    if (lep.isMuon){
+        if      (MVASUSY >  0.65) return 7; //Extra Tight
+        else if (MVASUSY >  0.45) return 6; //Very Tight
+        else if (MVASUSY >  0.15) return 5; //Tight
+        else if (MVASUSY > -0.20) return 4; //Medium
+        else if (MVASUSY > -0.60) return 3; //Loose
+        else if (MVASUSY > -0.90) return 2; //Very Loose
+    }
+    else if (lep.isElec){
+        if      (MVASUSY >  0.85) return 7; //Extra Tight
+        else if (MVASUSY >  0.75) return 6; //Very Tight
+        else if (MVASUSY >  0.65) return 5; //Tight
+        else if (MVASUSY >  0.50) return 4; //Medium
+        else if (MVASUSY >  0.25) return 3; //Loose
+        else if (MVASUSY > -0.30) return 2; //Very Loose
+    }
+  }
   return 1;
 }
 
@@ -511,22 +511,22 @@ Bool_t LeptonSelector::isGoodLepton(Lepton lep){
     return true;
   }
   else if(gSelection == iWZSelec){ // Fakeable Objects for the WZ analysis. MVA WP (and related selection criteria) are defined inside the proper analysis
-		Bool_t isMVALepton = true;    
-		if(lep.isMuon){
-			if(!isVetoLepton(lep)) isMVALepton = false;
-			if(TightCharge != 2) isMVALepton = false;
-			// Added MVA selection in the analysis
+    Bool_t isMVALepton = true;    
+    if(lep.isMuon){
+      if(!isVetoLepton(lep)) isMVALepton = false;
+      if(TightCharge != 2) isMVALepton = false;
+      // Added MVA selection in the analysis
     }
     if(lep.isElec){
-			if(!isVetoLepton(lep)) isMVALepton = false;
-			if(TightCharge != 2) isMVALepton = false;
-			if(!convVeto) isMVALepton = false;
-			// Added MVA selection in the analysis
+      if(!isVetoLepton(lep)) isMVALepton = false;
+      if(TightCharge != 2) isMVALepton = false;
+      if(!convVeto) isMVALepton = false;
+      // Added MVA selection in the analysis
     }
 
-		Bool_t isTopLepton = true;
-		//Top/Stop ID		
-		if(lep.isMuon){
+    Bool_t isTopLepton = true;
+    //Top/Stop ID    
+    if(lep.isMuon){
       passId  = getMuonId(iTight);
       passIso = getRelIso04POG(iTight);
     }
@@ -537,71 +537,71 @@ Bool_t LeptonSelector::isGoodLepton(Lepton lep){
     }
     if(lep.p.Pt() < 20 || TMath::Abs(lep.p.Eta()) > 2.4) isTopLepton = false;
     if(passId && passIso && ( (lep.isElec && getGoodVertex(iTight)) || (lep.isMuon && getGoodVertex(iMedium) ))){
-			isTopLepton = true;
-		}
+      isTopLepton = true;
+    }
     else isTopLepton = false;
 
-		if (isTopLepton && isMVALepton){
-	    lepMVASUSYId = getSUSYMVAId(lep, 2) + 10; //This is a terrible but quick way to do it
-			return true;
-		}
-		else if (isTopLepton && !(isMVALepton)){
-	    lepMVASUSYId = 10; //This is a terrible but quick way to do it
-			return true;	
-		}
-		else if ( (!isTopLepton) && isMVALepton){
-	    lepMVASUSYId = getSUSYMVAId(lep, 2); //This is a terrible but quick way to do it
-			return true;		
-		}
-		else return false;
+    if (isTopLepton && isMVALepton){
+      lepMVASUSYId = getSUSYMVAId(lep, 2) + 10; //This is a terrible but quick way to do it
+      return true;
+    }
+    else if (isTopLepton && !(isMVALepton)){
+      lepMVASUSYId = 10; //This is a terrible but quick way to do it
+      return true;  
+    }
+    else if ( (!isTopLepton) && isMVALepton){
+      lepMVASUSYId = getSUSYMVAId(lep, 2); //This is a terrible but quick way to do it
+      return true;    
+    }
+    else return false;
   }
   else if (gSelection == ittHSelec ) {
-    // 	Tight muons for multilepton ttH Analysis:
+    //   Tight muons for multilepton ttH Analysis:
     // abs(eta)<0.4, Pt>15, abs(dxy)<0.05cm, abs(dz)<0.1cm, SIP3D<8, Imini<0.4,
     // isLooseMuon==1,jetCSV<0.8484,isMediumMuon==1,tight-charge,lepMVA>0.90.
     //
-    // 	Tight electrons for multilepton ttH Analysis:
+    //   Tight electrons for multilepton ttH Analysis:
     // abs(eta)<0.5, Pt>15, abs(dxy)<0.05cm, abs(dz)<0.1cm, SIP3D<8, Imini<0.4,
     // jetCSV<0.8484,lepMVA>0.90,missinghits==0,conversion rej..
     // Furthermore, 3 regions in eta-phi space are defined: 0-0.8-1.479-2.5,
     // where: MVA ID>(0,0,0.7), sigmaietaieta<(0.011,0.011,0.031),
     // HoverE<(0.10,0.10,0.07), Deltaetain<(0.01,0.01,0.008),
-  	// Deltaphiin<(0.04,0.04,0.07),-0.05<1/E-1/p<(0.01,0.01,0.005)
-  	//
+    // Deltaphiin<(0.04,0.04,0.07),-0.05<1/E-1/p<(0.01,0.01,0.005)
+    //
     Bool_t passVertex; Bool_t passEta; Bool_t passPt; Bool_t passSIP;
     Bool_t passCSV; Bool_t passLepMVA; Bool_t passElecCutBasedId;
     Bool_t passptRatio;
     
-  	if (lep.isMuon) {
-  	  passEta 			     = (abs(eta) < 2.4);
-  	  passPt	 		       = (pt > 10);
-  	  passVertex		     = getGoodVertex(iTight);
-  	  passSIP			       = getSIPcut(8);
-  	  passIso			       = getminiRelIso(iTight);
-  	  passCSV			       = (jetBTagCSV < 0.8484);
-  	  passId			       = mediumMuonId;
-  	  passLepMVA		     = (MVATTH > 0.90);
+    if (lep.isMuon) {
+      passEta            = (abs(eta) < 2.4);
+      passPt              = (pt > 10);
+      passVertex         = getGoodVertex(iTight);
+      passSIP             = getSIPcut(8);
+      passIso             = getminiRelIso(iTight);
+      passCSV             = (jetBTagCSV < 0.8484);
+      passId             = mediumMuonId;
+      passLepMVA         = (MVATTH > 0.90);
 
-  	  passptRatio		     = 1;
-  	  passElecCutBasedId = 1;
-  	}
-  	if (lep.isElec) {
-  	  passEta 			     = (abs(eta) < 2.5);
-  	  passPt	 		       = (pt > 10);
-  	  passVertex		     = getGoodVertex(iTight);
-  	  passSIP			       = getSIPcut(8);
-  	  passIso			       = getminiRelIso(iTight);
-  	  passElecCutBasedId = getElecMVAId(iTight,lep);
-  	  passptRatio		     = 1;
-  	  passCSV			       = (jetBTagCSV < 0.8484);
-  	  passLepMVA		     = (MVATTH > 0.90);
+      passptRatio         = 1;
+      passElecCutBasedId = 1;
+    }
+    if (lep.isElec) {
+      passEta            = (abs(eta) < 2.5);
+      passPt              = (pt > 10);
+      passVertex         = getGoodVertex(iTight);
+      passSIP             = getSIPcut(8);
+      passIso             = getminiRelIso(iTight);
+      passElecCutBasedId = getElecMVAId(iTight,lep);
+      passptRatio         = 1;
+      passCSV             = (jetBTagCSV < 0.8484);
+      passLepMVA         = (MVATTH > 0.90);
 
-  	  passId			       = 1;
-  	}
-  	if (!passEta || !passPt || !passVertex || !passSIP || !passIso || !passCSV || !passId || !passLepMVA || !passptRatio || !passElecCutBasedId) return false;
-	return true;
+      passId             = 1;
+    }
+    if (!passEta || !passPt || !passVertex || !passSIP || !passIso || !passCSV || !passId || !passLepMVA || !passptRatio || !passElecCutBasedId) return false;
+  return true;
   }
-	return true;
+  return true;
 }
 
 //============================================== VETO LEPTONS
@@ -650,14 +650,14 @@ Bool_t LeptonSelector::isVetoLepton(Lepton lep){
   else if(gSelection == iWZSelec){ // Fakeable Objects for the WZ analysis
     if(lep.isMuon){
       if(lep.p.Pt() < 10) return false;
-			if(!isLooseLepton(lep)) return false;
-			if(!mediumMuonId) return false;
+      if(!isLooseLepton(lep)) return false;
+      if(!mediumMuonId) return false;
 
     }
     if(lep.isElec){
       if(lep.p.Pt() < 10) return false;
-			if(!isLooseLepton(lep)) return false;
-			if(lostHits > 0) return false;
+      if(!isLooseLepton(lep)) return false;
+      if(lostHits > 0) return false;
       if((sigmaIEtaIEta > 0.011 )*(lep.p.Eta() < 0.8) || (sigmaIEtaIEta > 0.011)*(lep.p.Eta() < 1.479)*(lep.p.Eta() > 0.8) || (sigmaIEtaIEta > 0.030)*(lep.p.Eta() > 1.479)) return false;
       if((HoE > 0.1)*(lep.p.Eta() < 0.8) || (HoE > 0.1)*(lep.p.Eta() < 1.479)*(lep.p.Eta() > 0.8) || (HoE > 0.07)*(lep.p.Eta() > 1.479)) return false;
       if((dEtaSC > 0.01)*(lep.p.Eta() < 0.8) || (dEtaSC > 0.01)*(lep.p.Eta() < 1.479)*(lep.p.Eta() > 0.8) || (dEtaSC > 0.008)*(lep.p.Eta() > 1.479)) return false;
@@ -665,61 +665,61 @@ Bool_t LeptonSelector::isVetoLepton(Lepton lep){
       if((eImpI<-0.05) || (eImpI > 0.01)*(lep.p.Eta() < 0.8) || (eImpI > 0.01)*(lep.p.Eta() < 1.479)*(lep.p.Eta() > 0.8) || (eImpI > 0.005)*(lep.p.Eta() > 1.479)) return false;
 
     }
-		lepMVASUSYId = getSUSYMVAId(lep, 1);
-		if (lepMVASUSYId < 0) return false;
+    lepMVASUSYId = getSUSYMVAId(lep, 1);
+    if (lepMVASUSYId < 0) return false;
     return true;
   }
   else if(gSelection == ittHSelec){
-  	// 	Fakeable muons for multilepton ttH Analysis:
-  	// Tight muons without medium muon ID, tight charge and lepton MVA cuts.
-  	//
-  	// 	Fakeable electrons for multilepton ttH Analysis:
-  	// Tight electrons without tight charge, conv. rej., lepton MVA cuts and
-  	// with ptratio > 0.5, if the electron fails tight selection (otherwise
-  	// w/o cut in ptratio) and, in this case too, with <0.3 jet CSV.
-  	//
-  	Bool_t passVertex; Bool_t passEta; Bool_t passPt; Bool_t passSIP;
-  	Bool_t passCSV; Bool_t passLepMVA; Bool_t passElecCutBasedId;
+    //   Fakeable muons for multilepton ttH Analysis:
+    // Tight muons without medium muon ID, tight charge and lepton MVA cuts.
+    //
+    //   Fakeable electrons for multilepton ttH Analysis:
+    // Tight electrons without tight charge, conv. rej., lepton MVA cuts and
+    // with ptratio > 0.5, if the electron fails tight selection (otherwise
+    // w/o cut in ptratio) and, in this case too, with <0.3 jet CSV.
+    //
+    Bool_t passVertex; Bool_t passEta; Bool_t passPt; Bool_t passSIP;
+    Bool_t passCSV; Bool_t passLepMVA; Bool_t passElecCutBasedId;
     Bool_t passptRatio; Bool_t passSegComp;
-  	if (lep.isMuon) {
-  	  passEta 		      = (abs(eta) < 2.4);
-  	  passPt	 		      = (pt > 10);
-  	  passVertex	      = getGoodVertex(iMedium);
-  	  passSIP			      = getSIPcut(8);
-  	  passIso			      = getminiRelIso(iLoose);
-  	  if (!isGoodLepton(lep)) {
-  	  	passCSV			       = (jetBTagCSV < 0.3);
-  	    passptRatio		     = (ptRatio > 0.5);
-  	    passSegComp		     = (SegComp > 0.3);
-  	  } else {
-  	  	passCSV			       = (jetBTagCSV < 0.8484);
-  	    passptRatio		     = 1;
-  	    passSegComp		     = 1;
-  	  }
-  	  passId			       = 1;
-  	  passLepMVA		     = 1;
-  	  passElecCutBasedId = 1;
-  	}
-  	if (lep.isElec) {
-  	  passEta 		       = (abs(eta) < 2.5);
-  	  passPt	 		       = (pt > 10);
-  	  passVertex	       = getGoodVertex(iMedium);
-  	  passSIP			       = getSIPcut(8);
-  	  passIso			       = getminiRelIso(iLoose);
-  	  passElecCutBasedId = getElecMVAId(iLoose,lep);
-  	  if (!isGoodLepton(lep)) {
-  	    passptRatio		     = (ptRatio > 0.5);
-  	  	passCSV				     = (jetBTagCSV < 0.3);
-  	  } else {
-  	  	passptRatio		     = 1;
-  	  	passCSV				     = (jetBTagCSV < 0.8484);
-  	  }
+    if (lep.isMuon) {
+      passEta           = (abs(eta) < 2.4);
+      passPt             = (pt > 10);
+      passVertex        = getGoodVertex(iMedium);
+      passSIP            = getSIPcut(8);
+      passIso            = getminiRelIso(iLoose);
+      if (!isGoodLepton(lep)) {
+        passCSV             = (jetBTagCSV < 0.3);
+        passptRatio         = (ptRatio > 0.5);
+        passSegComp         = (SegComp > 0.3);
+      } else {
+        passCSV             = (jetBTagCSV < 0.8484);
+        passptRatio         = 1;
+        passSegComp         = 1;
+      }
+      passId             = 1;
+      passLepMVA         = 1;
+      passElecCutBasedId = 1;
+    }
+    if (lep.isElec) {
+      passEta            = (abs(eta) < 2.5);
+      passPt              = (pt > 10);
+      passVertex         = getGoodVertex(iMedium);
+      passSIP             = getSIPcut(8);
+      passIso             = getminiRelIso(iLoose);
+      passElecCutBasedId = getElecMVAId(iLoose,lep);
+      if (!isGoodLepton(lep)) {
+        passptRatio         = (ptRatio > 0.5);
+        passCSV             = (jetBTagCSV < 0.3);
+      } else {
+        passptRatio         = 1;
+        passCSV             = (jetBTagCSV < 0.8484);
+      }
 
-  	  passLepMVA			  = 1;
-  	  passId					  = 1;
-      passSegComp			  = 1;
-  	}
-  	if (!passEta || !passPt || !passVertex || !passSIP || !passIso || !passCSV || !passId || !passLepMVA || !passptRatio || !passElecCutBasedId || !passSegComp) return false;
+      passLepMVA        = 1;
+      passId            = 1;
+      passSegComp        = 1;
+    }
+    if (!passEta || !passPt || !passVertex || !passSIP || !passIso || !passCSV || !passId || !passLepMVA || !passptRatio || !passElecCutBasedId || !passSegComp) return false;
     return true;
   }
   return false;
@@ -753,60 +753,60 @@ Bool_t LeptonSelector::isLooseLepton(Lepton lep){
     if(lep.isMuon){
       if(lep.p.Pt() < 5) return false;
       if(TMath::Abs(lep.p.Eta()) > 2.4) return false;
-			if(!getGoodVertex(iLoose)) return false;
-			if(!getSIPcut(8)) return false;
-			if(!getminiRelIso(iLoose)) return false;
+      if(!getGoodVertex(iLoose)) return false;
+      if(!getSIPcut(8)) return false;
+      if(!getminiRelIso(iLoose)) return false;
     }
     if(lep.isElec){
       if(lep.p.Pt() < 7) return false;
       if(TMath::Abs(lep.p.Eta()) > 2.5) return false;
-			if(!getGoodVertex(iLoose)) return false;		
-			if(!getSIPcut(8)) return false;
-			if(!getminiRelIso(iLoose)) return false;
-  	  if(!getElecMVAId(iLoose,lep)) return false;	
+      if(!getGoodVertex(iLoose)) return false;    
+      if(!getSIPcut(8)) return false;
+      if(!getminiRelIso(iLoose)) return false;
+      if(!getElecMVAId(iLoose,lep)) return false;  
       if((MVAID < -0.70)*(lep.p.Eta() < 0.8) || (MVAID < -0.83)*(lep.p.Eta() < 1.479)*(lep.p.Eta() > 0.8) || (MVAID < -0.92)*(lep.p.Eta() > 1.479)) return false;
-			if(lostHits > 2) return false;
+      if(lostHits > 2) return false;
     }
     return true;
   }
   if(gSelection == ittHSelec){
-  	// 	Loose muons for multilepton ttH Analysis:
-  	// Fakeable muons without jetCSV cut and with pt>5.
-  	//
-  	// 	Loose electrons for multilepton ttH Analysis:
-  	// Fakeable electrons with Nmissinghits<2 and pt>7 and without jetCSV,
-  	// ptratio, 1/E-1/p, deltaPhiin, deltaEtain, H/E, sigmaietaieta cuts
-  	//
-  	Bool_t passVertex; Bool_t passEta; Bool_t passPt; Bool_t passSIP;
-  	Bool_t passCSV; Bool_t passLepMVA; Bool_t passElecCutBasedId; 
+    //   Loose muons for multilepton ttH Analysis:
+    // Fakeable muons without jetCSV cut and with pt>5.
+    //
+    //   Loose electrons for multilepton ttH Analysis:
+    // Fakeable electrons with Nmissinghits<2 and pt>7 and without jetCSV,
+    // ptratio, 1/E-1/p, deltaPhiin, deltaEtain, H/E, sigmaietaieta cuts
+    //
+    Bool_t passVertex; Bool_t passEta; Bool_t passPt; Bool_t passSIP;
+    Bool_t passCSV; Bool_t passLepMVA; Bool_t passElecCutBasedId; 
     Bool_t passptRatio;
-  	if (lep.isMuon) {
-  	  passEta 		       = (abs(eta) < 2.4);
-  	  passPt	 		       = (pt > 5);
-  	  passVertex		     = getGoodVertex(iLoose);
-  	  passSIP			       = getSIPcut(8);
-  	  passIso			       = getminiRelIso(iLoose);
+    if (lep.isMuon) {
+      passEta            = (abs(eta) < 2.4);
+      passPt              = (pt > 5);
+      passVertex         = getGoodVertex(iLoose);
+      passSIP             = getSIPcut(8);
+      passIso             = getminiRelIso(iLoose);
 
-  	  passCSV		         = 1;
-  	  passId			       = 1;
-  	  passLepMVA		     = 1;
-  	  passptRatio		     = 1;
-  	  passElecCutBasedId = 1;
-  	}
-  	if (lep.isElec) {
-  	  passEta 			     = (abs(eta) < 2.5);
-  	  passPt	 		       = (pt > 7);
-  	  passVertex		     = getGoodVertex(iLoose);
-  	  passSIP			       = getSIPcut(8);
-  	  passIso			       = getminiRelIso(iLoose);
-  	  passElecCutBasedId = getElecMVAId(iLoose,lep);
+      passCSV             = 1;
+      passId             = 1;
+      passLepMVA         = 1;
+      passptRatio         = 1;
+      passElecCutBasedId = 1;
+    }
+    if (lep.isElec) {
+      passEta            = (abs(eta) < 2.5);
+      passPt              = (pt > 7);
+      passVertex         = getGoodVertex(iLoose);
+      passSIP             = getSIPcut(8);
+      passIso             = getminiRelIso(iLoose);
+      passElecCutBasedId = getElecMVAId(iLoose,lep);
 
-  	  passptRatio		     = 1;
-  	  passCSV			       = 1;
-  	  passLepMVA		     = 1;
-  	  passId			       = 1;
-  	}
-  	if (!passEta || !passPt || !passVertex || !passSIP || !passIso || !passCSV || !passId || !passLepMVA || !passptRatio || !passElecCutBasedId) return false;
+      passptRatio         = 1;
+      passCSV             = 1;
+      passLepMVA         = 1;
+      passId             = 1;
+    }
+    if (!passEta || !passPt || !passVertex || !passSIP || !passIso || !passCSV || !passId || !passLepMVA || !passptRatio || !passElecCutBasedId) return false;
     return true;
   }
     return true;
@@ -840,7 +840,7 @@ void LeptonSelector::InsideLoop(){
       //if(1){
       tL.SetSF(   LepSF->GetLeptonSF(     pt, eta, tL.type) ); // Set SF and error
       tL.SetSFerr(LepSF->GetLeptonSFerror(pt, eta, tL.type) );
-			if(gSelection == iWZSelec) tL.idMVA = lepMVASUSYId;
+      if(gSelection == iWZSelec) tL.idMVA = lepMVASUSYId;
       selLeptons.push_back(tL);
     }
     else DumpEvent(evt, Form(" >>> Lepton %i (pt = %g, eta = %g, type = %i): NO PASA", i, tP.Pt(), tP.Eta(), type));
@@ -849,7 +849,7 @@ void LeptonSelector::InsideLoop(){
       if(gSelection == i4tSelec){
         if(!isGoodLepton(tL)) vetoLeptons.push_back(tL);
       }
-			if(gSelection == iWZSelec) tL.idMVA = lepMVASUSYId;
+      if(gSelection == iWZSelec) tL.idMVA = lepMVASUSYId;
       else vetoLeptons.push_back(tL);
     }
     if(isLooseLepton(tL)){ // A loose category... used in ttH, for example
@@ -905,10 +905,10 @@ void LeptonSelector::InsideLoop(){
       }
     }
   }
-  nSelLeptons 	= selLeptons.size();
-  nVetoLeptons 	= vetoLeptons.size();
+  nSelLeptons   = selLeptons.size();
+  nVetoLeptons   = vetoLeptons.size();
   nLooseLeptons = looseLeptons.size();
-  nGenLeptons  	= genLeptons.size();
+  nGenLeptons    = genLeptons.size();
 
   TriggerSF = 1; TriggerSFerr = 0;
   if(gSelection == iTopSelec || gSelection == iStopTopSelec || gSelection == iTWSelec || gSelection == iStopSelec){
@@ -955,34 +955,34 @@ void LeptonSelector::InsideLoop(){
 void LeptonSelector::GetLeptonVariables(Int_t i){ // Once per muon, get all the info
   //tP.SetPxPyPzE(Get<Float_t>("LepGood_px", i), Get<Float_t>("LepGood_py", i), Get<Float_t>("LepGood_pz", i), Get<Float_t>("LepGood_energy", i));
   tP.SetPtEtaPhiM(Get<Float_t>("LepGood_pt", i), Get<Float_t>("LepGood_eta", i), Get<Float_t>("LepGood_phi", i), Get<Float_t>("LepGood_mass", i));
-  pt 						= tP.Pt();
-  eta 					= tP.Eta();
-  charge 				= Get<Int_t>("LepGood_charge", i);
-  type 					= TMath::Abs(Get<Int_t>("LepGood_pdgId",i)) == 11 ? 1 : 0;
-  tightVar 			= Get<Int_t>("LepGood_tightId", i);
-  mediumMuonId 	= Get<Int_t>("LepGood_mediumMuonId",i);
-  etaSC 				= TMath::Abs(Get<Float_t>("LepGood_etaSc",i));
-  RelIso03 			= Get<Float_t>("LepGood_relIso03",i);
-  RelIso04 			= Get<Float_t>("LepGood_relIso04",i);
-  ptRel 				= Get<Float_t>("LepGood_jetPtRelv2",i);
-  ptRatio 			= Get<Float_t>("LepGood_jetPtRatiov2",i);
-  miniIso 			= Get<Float_t>("LepGood_miniRelIso",i);
-  dxy 					= TMath::Abs(Get<Float_t>("LepGood_dxy", i));
-  dz  					= TMath::Abs(Get<Float_t>("LepGood_dz", i));
+  pt             = tP.Pt();
+  eta           = tP.Eta();
+  charge         = Get<Int_t>("LepGood_charge", i);
+  type           = TMath::Abs(Get<Int_t>("LepGood_pdgId",i)) == 11 ? 1 : 0;
+  tightVar       = Get<Int_t>("LepGood_tightId", i);
+  mediumMuonId   = Get<Int_t>("LepGood_mediumMuonId",i);
+  etaSC         = TMath::Abs(Get<Float_t>("LepGood_etaSc",i));
+  RelIso03       = Get<Float_t>("LepGood_relIso03",i);
+  RelIso04       = Get<Float_t>("LepGood_relIso04",i);
+  ptRel         = Get<Float_t>("LepGood_jetPtRelv2",i);
+  ptRatio       = Get<Float_t>("LepGood_jetPtRatiov2",i);
+  miniIso       = Get<Float_t>("LepGood_miniRelIso",i);
+  dxy           = TMath::Abs(Get<Float_t>("LepGood_dxy", i));
+  dz            = TMath::Abs(Get<Float_t>("LepGood_dz", i));
   sigmaIEtaIEta = Get<Float_t>("LepGood_sigmaIEtaIEta", i);
-  dEtaSC 				= Get<Float_t>("LepGood_dEtaScTrkIn", i);
-  dPhiSC 				= Get<Float_t>("LepGood_dPhiScTrkIn", i);
-  HoE    				= Get<Float_t>("LepGood_hadronicOverEm", i);
-  eImpI  				= Get<Float_t>("LepGood_eInvMinusPInv", i);
-  lostHits 			= Get<Int_t>("LepGood_lostHits", i);
-  convVeto 			= Get<Int_t>("LepGood_convVeto", i);
-  sip 					= Get<Float_t>("LepGood_sip3d",i);
-  MVATTH				= Get<Float_t>("LepGood_mvaTTH",i); 			//*
-  MVASUSY				= Get<Float_t>("LepGood_mvaSUSY",i); 			//*
-  TightCharge		= Get<Int_t>("LepGood_tightCharge",i);			//*
-  MVAID					= Get<Float_t>("LepGood_mvaIdSpring16GP",i); 	//*
-  jetBTagCSV		= Get<Float_t>("LepGood_jetBTagCSV",i); 	//*
-  SegComp				= Get<Float_t>("LepGood_segmentCompatibility",i); 	//*
+  dEtaSC         = Get<Float_t>("LepGood_dEtaScTrkIn", i);
+  dPhiSC         = Get<Float_t>("LepGood_dPhiScTrkIn", i);
+  HoE            = Get<Float_t>("LepGood_hadronicOverEm", i);
+  eImpI          = Get<Float_t>("LepGood_eInvMinusPInv", i);
+  lostHits       = Get<Int_t>("LepGood_lostHits", i);
+  convVeto       = Get<Int_t>("LepGood_convVeto", i);
+  sip           = Get<Float_t>("LepGood_sip3d",i);
+  MVATTH        = Get<Float_t>("LepGood_mvaTTH",i);       //*
+  MVASUSY        = Get<Float_t>("LepGood_mvaSUSY",i);       //*
+  TightCharge    = Get<Int_t>("LepGood_tightCharge",i);      //*
+  MVAID          = Get<Float_t>("LepGood_mvaIdSpring16GP",i);   //*
+  jetBTagCSV    = Get<Float_t>("LepGood_jetBTagCSV",i);   //*
+  SegComp        = Get<Float_t>("LepGood_segmentCompatibility",i);   //*
   isGlobalMuon = Get<Int_t>("LepGood_isGlobalMuon",i);
   isTrackerMuon = Get<Int_t>("LepGood_isTrackerMuon",i);
 
@@ -991,34 +991,34 @@ void LeptonSelector::GetLeptonVariables(Int_t i){ // Once per muon, get all the 
 
 void LeptonSelector::GetDiscLeptonVariables(Int_t i){ // Once per muon, get all the info
   tP.SetPxPyPzE(Get<Float_t>("DiscLep_px", i), Get<Float_t>("DiscLep_py", i), Get<Float_t>("DiscLep_pz", i), Get<Float_t>("DiscLep_energy", i));
-  pt 						= tP.Pt();
-  eta 					= tP.Eta();
-  charge 				= Get<Int_t>("DiscLep_charge", i);
-  type 					= TMath::Abs(Get<Int_t>("DiscLep_pdgId",i)) == 11 ? 1 : 0;
-  tightVar 			= Get<Int_t>("DiscLep_tightId", i);
-  mediumMuonId 	= Get<Int_t>("DiscLep_mediumMuonId",i);
-  etaSC 				= TMath::Abs(Get<Float_t>("DiscLep_etaSc",i));
-  RelIso03 			= Get<Float_t>("DiscLep_relIso03",i);
-  RelIso04 			= Get<Float_t>("DiscLep_relIso04",i);
-  ptRel 				= Get<Float_t>("DiscLep_jetPtRelv2",i);
-  ptRatio 			= Get<Float_t>("DiscLep_jetPtRatiov2",i);
-  miniIso 			= Get<Float_t>("DiscLep_miniRelIso",i);
-  dxy 					= TMath::Abs(Get<Float_t>("DiscLep_dxy", i));
-  dz  					= TMath::Abs(Get<Float_t>("DiscLep_dz", i));
+  pt             = tP.Pt();
+  eta           = tP.Eta();
+  charge         = Get<Int_t>("DiscLep_charge", i);
+  type           = TMath::Abs(Get<Int_t>("DiscLep_pdgId",i)) == 11 ? 1 : 0;
+  tightVar       = Get<Int_t>("DiscLep_tightId", i);
+  mediumMuonId   = Get<Int_t>("DiscLep_mediumMuonId",i);
+  etaSC         = TMath::Abs(Get<Float_t>("DiscLep_etaSc",i));
+  RelIso03       = Get<Float_t>("DiscLep_relIso03",i);
+  RelIso04       = Get<Float_t>("DiscLep_relIso04",i);
+  ptRel         = Get<Float_t>("DiscLep_jetPtRelv2",i);
+  ptRatio       = Get<Float_t>("DiscLep_jetPtRatiov2",i);
+  miniIso       = Get<Float_t>("DiscLep_miniRelIso",i);
+  dxy           = TMath::Abs(Get<Float_t>("DiscLep_dxy", i));
+  dz            = TMath::Abs(Get<Float_t>("DiscLep_dz", i));
   sigmaIEtaIEta = Get<Float_t>("DiscLep_sigmaIEtaIEta", i);
-  dEtaSC 				= Get<Float_t>("DiscLep_dEtaScTrkIn", i);
-  dPhiSC 				= Get<Float_t>("DiscLep_dPhiScTrkIn", i);
-  HoE    				= Get<Float_t>("DiscLep_hadronicOverEm", i);
-  eImpI  				= Get<Float_t>("DiscLep_eInvMinusPInv", i);
-  lostHits 			= Get<Int_t>("DiscLep_lostHits", i);
-  convVeto 			= Get<Int_t>("DiscLep_convVeto", i);
-  sip 					= Get<Float_t>("DiscLep_sip3d",i);
-  MVATTH				= Get<Float_t>("DiscLep_mvaTTH",i); 			//*
-  MVASUSY				= Get<Float_t>("DiscLep_mvaSUSY",i); 			//*
-  TightCharge		= Get<Int_t>("DiscLep_tightCharge",i);			//*
-  MVAID					= Get<Float_t>("DiscLep_mvaIdSpring16GP",i); 	//*
-  jetBTagCSV		= Get<Float_t>("DiscLep_jetBTagCSV",i); 	//*
-  SegComp				= Get<Float_t>("DiscLep_segmentCompatibility",i); 	//*
+  dEtaSC         = Get<Float_t>("DiscLep_dEtaScTrkIn", i);
+  dPhiSC         = Get<Float_t>("DiscLep_dPhiScTrkIn", i);
+  HoE            = Get<Float_t>("DiscLep_hadronicOverEm", i);
+  eImpI          = Get<Float_t>("DiscLep_eInvMinusPInv", i);
+  lostHits       = Get<Int_t>("DiscLep_lostHits", i);
+  convVeto       = Get<Int_t>("DiscLep_convVeto", i);
+  sip           = Get<Float_t>("DiscLep_sip3d",i);
+  MVATTH        = Get<Float_t>("DiscLep_mvaTTH",i);       //*
+  MVASUSY        = Get<Float_t>("DiscLep_mvaSUSY",i);       //*
+  TightCharge    = Get<Int_t>("DiscLep_tightCharge",i);      //*
+  MVAID          = Get<Float_t>("DiscLep_mvaIdSpring16GP",i);   //*
+  jetBTagCSV    = Get<Float_t>("DiscLep_jetBTagCSV",i);   //*
+  SegComp        = Get<Float_t>("DiscLep_segmentCompatibility",i);   //*
   isGlobalMuon = Get<Int_t>("DiscLep_isGlobalMuon",i);
   isTrackerMuon = Get<Int_t>("DiscLep_isTrackerMuon",i);
 

--- a/packages/LeptonSelector/LeptonSelector.C
+++ b/packages/LeptonSelector/LeptonSelector.C
@@ -314,7 +314,7 @@ Bool_t LeptonSelector::getElecCutBasedId(Int_t wp){
   }
   else if(gSelection == iWZSelec)
     {
-      return true; // Me la pela, porque selecciono IDs multiplos dentro del paquete de analisis
+      return true; // Selección de ID dentro del paquete de analisis
     }
   else{
     if(wp == iTight   && tightVar < 3)     return false;

--- a/packages/LeptonSelector/LeptonSelector.C
+++ b/packages/LeptonSelector/LeptonSelector.C
@@ -469,27 +469,20 @@ Bool_t LeptonSelector::isGoodLepton(Lepton lep){
     if(TightCharge != 2) return false;
     return true;
   }
-  else if (gSelection == iWZSelec) // Todo lo que esta mas para alla de una seleccion basica se hace en el paquete de analisis
-    {
-      if(lep.isMuon){
-        DumpVar(evt, "!isGlobalMuon && !isTrackerMuon", isGlobalMuon || isTrackerMuon, isGlobalMuon || isTrackerMuon);
-        DumpVar(evt, "getMuonId(iMedium)", getMuonId(iMedium), getMuonId(iMedium));
-        if(lep.p.Pt() < 10) return false;
-        if(TMath::Abs(lep.p.Eta()) > 2.4) return false;
-      }
-      if(lep.isElec){
-        DumpVar(evt, "getElecCutBasedId(iLoose)", getElecCutBasedId(iLoose), getElecCutBasedId(iLoose));
-        DumpVar(evt, "convVeto", convVeto, convVeto);
-        DumpVar(evt, "lostHits", lostHits, lostHits == 0);
-        DumpVar(evt, "getElecMVA(iTight)", getElecMVA(iTight), getElecMVA(iTight));
-        if(lep.p.Pt() < 10) return false;
-        if(TMath::Abs(lep.p.Eta()) > 2.5) return false;
-      }
-      //if(!getminiRelIso(iLoose)) return false;
-      DumpVar(evt, "getSIPcut(4)", sip, getSIPcut(4)); 
-      DumpVar(evt, "TightCharge == 2", TightCharge, TightCharge == 2); 
-      return true;
+  else if(gSelection == iWZSelec){ // Fakeable Objects for the WZ analysis. MVA WP (and related selection criteria) are defined inside the proper analysis
+    if(lep.isMuon){
+			if(!isVetoLepton(lep)) return false;
+			if(TightCharge != 2) return false;
+			// Added MVA selection in the analysis
     }
+    if(lep.isElec){
+			if(!isVetoLepton(lep)) return false;
+			if(TightCharge != 2) return false;
+			if(!convVeto) return false;
+			// Added MVA selection in the analysis
+    }
+    return true;
+  }
   else if (gSelection == ittHSelec ) {
     // 	Tight muons for multilepton ttH Analysis:
     // abs(eta)<0.4, Pt>15, abs(dxy)<0.05cm, abs(dz)<0.1cm, SIP3D<8, Imini<0.4,
@@ -582,14 +575,23 @@ Bool_t LeptonSelector::isVetoLepton(Lepton lep){
     if(TightCharge != 2) return false;
     return true;
   }
-  else if(gSelection == iWZSelec){ // Todo lo que esta mas para alla se hace dentro del paquete de analisis
+  else if(gSelection == iWZSelec){ // Fakeable Objects for the WZ analysis. MVA WP (and related selection criteria) are defined inside the proper analysis
     if(lep.isMuon){
       if(lep.p.Pt() < 10) return false;
-      if(TMath::Abs(lep.p.Eta()) > 2.4) return false;
+			if(!isLooseLepton(lep)) return false;
+			if(!mediumMuonId) return false;
+			// Added CSV and p_T^ratio cuts (only if no MVA cut is passed) in analysis
     }
     if(lep.isElec){
       if(lep.p.Pt() < 10) return false;
-      if(TMath::Abs(lep.p.Eta()) > 2.5) return false;
+			if(!isLooseLepton(lep)) return false;
+			if(lostHits > 0) return false;
+      if((sigmaIEtaIEta > 0.011 )*(lep.p.Eta() < 0.8) || (sigmaIEtaIEta > 0.011)*(lep.p.Eta() < 1.479)*(lep.p.Eta() > 0.8) || (sigmaIEtaIEta > 0.030)*(lep.p.Eta() > 1.479)) return false;
+      if((HoE > 0.1)*(lep.p.Eta() < 0.8) || (HoE > 0.1)*(lep.p.Eta() < 1.479)*(lep.p.Eta() > 0.8) || (HoE > 0.07)*(lep.p.Eta() > 1.479)) return false;
+      if((dEtaSC > 0.01)*(lep.p.Eta() < 0.8) || (dEtaSC > 0.01)*(lep.p.Eta() < 1.479)*(lep.p.Eta() > 0.8) || (dEtaSC > 0.008)*(lep.p.Eta() > 1.479)) return false;
+      if((dPhiSC > 0.04)*(lep.p.Eta() < 0.8) || (dPhiSC > 0.04)*(lep.p.Eta() < 1.479)*(lep.p.Eta() > 0.8) || (dPhiSC > 0.07)*(lep.p.Eta() > 1.479)) return false;
+      if((eImpI<-0.05) || (eImpI > 0.01)*(lep.p.Eta() < 0.8) || (eImpI > 0.01)*(lep.p.Eta() < 1.479)*(lep.p.Eta() > 0.8) || (eImpI > 0.005)*(lep.p.Eta() > 1.479)) return false;
+			// Added CSV, MVAID and p_T^ratio cuts (only if no MVA cut is passed) in analysis
     }
     return true;
   }
@@ -673,14 +675,23 @@ Bool_t LeptonSelector::isLooseLepton(Lepton lep){
     if(!getGoodVertex(iTight)) return false;
     return true;
   }
-  if(gSelection == iWZSelec){ // Todo lo que esta mas para alla se hace dentro del paquete de analisis
+  else if(gSelection == iWZSelec){ // Loose leptons are common to all tight WP
     if(lep.isMuon){
-      if(lep.p.Pt() < 10) return false;
+      if(lep.p.Pt() < 5) return false;
       if(TMath::Abs(lep.p.Eta()) > 2.4) return false;
+			if(!getGoodVertex(iLoose)) return false;
+			if(!getSIPcut(8)) return false;
+			if(!getminiRelIso(iLoose)) return false;
     }
     if(lep.isElec){
-      if(lep.p.Pt() < 10) return false;
+      if(lep.p.Pt() < 7) return false;
       if(TMath::Abs(lep.p.Eta()) > 2.5) return false;
+			if(!getGoodVertex(iLoose)) return false;		
+			if(!getSIPcut(8)) return false;
+			if(!getminiRelIso(iLoose)) return false;
+  	  if(!getElecMVAId(iLoose,lep)) return false;	
+      if((MVAID < -0.70)*(lep.p.Eta() < 0.8) || (MVAID < -0.83)*(lep.p.Eta() < 1.479)*(lep.p.Eta() > 0.8) || (MVAID < -0.92)*(lep.p.Eta() > 1.479)) return false;
+			if(lostHits > 2) return false;
     }
     return true;
   }
@@ -891,6 +902,7 @@ void LeptonSelector::GetLeptonVariables(Int_t i){ // Once per muon, get all the 
   convVeto 			= Get<Int_t>("LepGood_convVeto", i);
   sip 					= Get<Float_t>("LepGood_sip3d",i);
   MVATTH				= Get<Float_t>("LepGood_mvaTTH",i); 			//*
+  MVASUSY				= Get<Float_t>("LepGood_mvaSUSY",i); 			//*
   TightCharge		= Get<Int_t>("LepGood_tightCharge",i);			//*
   MVAID					= Get<Float_t>("LepGood_mvaIdSpring16GP",i); 	//*
   jetBTagCSV		= Get<Float_t>("LepGood_jetBTagCSV",i); 	//*
@@ -926,6 +938,7 @@ void LeptonSelector::GetDiscLeptonVariables(Int_t i){ // Once per muon, get all 
   convVeto 			= Get<Int_t>("DiscLep_convVeto", i);
   sip 					= Get<Float_t>("DiscLep_sip3d",i);
   MVATTH				= Get<Float_t>("DiscLep_mvaTTH",i); 			//*
+  MVASUSY				= Get<Float_t>("DiscLep_mvaSUSY",i); 			//*
   TightCharge		= Get<Int_t>("DiscLep_tightCharge",i);			//*
   MVAID					= Get<Float_t>("DiscLep_mvaIdSpring16GP",i); 	//*
   jetBTagCSV		= Get<Float_t>("DiscLep_jetBTagCSV",i); 	//*

--- a/packages/LeptonSelector/LeptonSelector.h
+++ b/packages/LeptonSelector/LeptonSelector.h
@@ -72,6 +72,7 @@ class LeptonSelector : public PAFChainItemSelector{
     Float_t SegComp;
     Int_t isGlobalMuon;
     Int_t isTrackerMuon;
+		Int_t lepMVASUSYId;
     
     // genLeptons
     Int_t ngenLep;
@@ -101,6 +102,7 @@ class LeptonSelector : public PAFChainItemSelector{
     Bool_t isGoodLepton(Lepton lep);
     Bool_t isLooseLepton(Lepton lep);
     Bool_t isVetoLepton(Lepton lep);
+		Int_t  getSUSYMVAId(Lepton lep, Int_t ty);
 
   ClassDef(LeptonSelector, 0);
 };

--- a/packages/LeptonSelector/LeptonSelector.h
+++ b/packages/LeptonSelector/LeptonSelector.h
@@ -43,10 +43,10 @@ class LeptonSelector : public PAFChainItemSelector{
     TLorentzVector tP; 
     Float_t pt;
     Float_t eta;
-    Int_t 	charge; 
-    Int_t 	type;
-    Int_t 	tightVar;
-    Int_t 	mediumMuonId;
+    Int_t   charge; 
+    Int_t   type;
+    Int_t   tightVar;
+    Int_t   mediumMuonId;
     Float_t etaSC;
     Float_t RelIso03;
     Float_t RelIso04;
@@ -65,14 +65,14 @@ class LeptonSelector : public PAFChainItemSelector{
     Float_t sip;
     Float_t SF;
     Float_t MVATTH;
-		Float_t MVASUSY;
-    Int_t	TightCharge;
+    Float_t MVASUSY;
+    Int_t  TightCharge;
     Float_t MVAID;
     Float_t jetBTagCSV;
     Float_t SegComp;
     Int_t isGlobalMuon;
     Int_t isTrackerMuon;
-		Int_t lepMVASUSYId;
+    Int_t lepMVASUSYId;
     
     // genLeptons
     Int_t ngenLep;
@@ -102,7 +102,7 @@ class LeptonSelector : public PAFChainItemSelector{
     Bool_t isGoodLepton(Lepton lep);
     Bool_t isLooseLepton(Lepton lep);
     Bool_t isVetoLepton(Lepton lep);
-		Int_t  getSUSYMVAId(Lepton lep, Int_t ty);
+    Int_t  getSUSYMVAId(Lepton lep, Int_t ty);
 
   ClassDef(LeptonSelector, 0);
 };

--- a/packages/LeptonSelector/LeptonSelector.h
+++ b/packages/LeptonSelector/LeptonSelector.h
@@ -65,6 +65,7 @@ class LeptonSelector : public PAFChainItemSelector{
     Float_t sip;
     Float_t SF;
     Float_t MVATTH;
+		Float_t MVASUSY;
     Int_t	TightCharge;
     Float_t MVAID;
     Float_t jetBTagCSV;

--- a/packages/WZAnalysis/WZAnalysis.C
+++ b/packages/WZAnalysis/WZAnalysis.C
@@ -9,7 +9,6 @@ WZAnalysis::WZAnalysis() : PAFChainItemSelector() {
   fhDummy = 0;
   passMETfilters = 0;
   passTrigger    = 0;
-  isSS           = 0;
 
   for(Int_t i = 0; i < 254; i++) TLHEWeight[i] = 0;
   
@@ -44,7 +43,6 @@ WZAnalysis::WZAnalysis() : PAFChainItemSelector() {
         if(cut == 0){
           fHyields[ch][sys]     = 0;
           fHFiduYields[ch][sys]     = 0;
-          fHSSyields[ch][sys]   = 0;
         }
       }
     }
@@ -71,17 +69,6 @@ void WZAnalysis::Initialise(){
     SetEventVariables();
   }
   InitHistos();
-
-  // genLeptons  = std::vector<Lepton>();
-  // selLeptons  = std::vector<Lepton>();
-  // vetoLeptons = std::vector<Lepton>();
-  // selJets = std::vector<Jet>();
-  // selJetsJecUp = std::vector<Jet>();
-  // selJetsJecDown = std::vector<Jet>();
-  // Jets15  = std::vector<Jet>();
-  // genJets = std::vector<Jet>();
-  // mcJets  = std::vector<Jet>();
-  // vetoJets = std::vector<Jet>();
 }
 
 void WZAnalysis::InsideLoop(){
@@ -108,7 +95,7 @@ void WZAnalysis::InsideLoop(){
   gChannel       = GetParam<Int_t>("gChannel");
   passMETfilters = GetParam<Bool_t>("METfilters");
   passTrigger    = GetParam<Bool_t>("passTrigger");
-  isSS           = GetParam<Bool_t>("isSS");
+
   // Leptons and Jets
   GetLeptonVariables(selLeptons, vetoLeptons);
   GetJetVariables(selJets, Jets15);
@@ -116,42 +103,12 @@ void WZAnalysis::InsideLoop(){
   GetMET();
   fhDummy->Fill(1);
 
-  // Number of events in fiducial region
-  if(genLeptons.size() >= 2){ // MIND THE POSSIBLE SKIM (on reco leptons) IN THE SAMPLE!!
-    Int_t GenChannel = -1;
-    if(genLeptons.at(0).isElec && genLeptons.at(1).isMuon) GenChannel = iElMu; 
-    if(genLeptons.at(0).isMuon && genLeptons.at(1).isElec) GenChannel = iElMu; 
-    if(genLeptons.at(0).isMuon && genLeptons.at(1).isMuon) GenChannel = iMuon; 
-    if(genLeptons.at(0).isElec && genLeptons.at(1).isElec) GenChannel = iElec; 
-    if( ( (genLeptons.at(0).p.Pt() > 25 && genLeptons.at(1).p.Pt() > 20) || (genLeptons.at(0).p.Pt() > 20 && genLeptons.at(1).p.Pt() > 25) )
-        && (TMath::Abs(genLeptons.at(0).p.Eta()) < 2.4 && TMath::Abs(genLeptons.at(1).p.Eta()) < 2.4) 
-        && ( (genLeptons.at(0).p + genLeptons.at(1).p).M() > 20 ) ){
-      fHFiduYields[GenChannel-1][0] -> Fill(idilepton);
-      if(GenChannel == iElMu || (TMath::Abs((genLeptons.at(0).p + genLeptons.at(1).p).M() - 91) > 15) ){
-        fHFiduYields[GenChannel-1][0] -> Fill(iZVeto);
-        if(GenChannel == iElMu || TGenMET > 40){   // MET > 40 in ee, µµ
-          fHFiduYields[GenChannel-1][0] -> Fill(iMETcut);
-          if(nFiduJets >= 2){ //At least 2 jets
-            fHFiduYields[GenChannel-1][0] -> Fill(i2jets);
-            if(nFidubJets >= 1){ // At least 1 b-tag
-              fHFiduYields[GenChannel-1][0] -> Fill(i1btag);
-            }
-          }
-        }
-      }
-    }
-  }
-
-  // Here I redefine my leptons and multiple selections
+  // FIXME: Here I might redefine my leptons and multiple selections
   makeLeptonCollections();
 
-   //if((Int_t) genLeptons.size() >=2 && TNSelLeps >= 2 && passTrigger && passMETfilters){ // dilepton event, 2 leptons // && !isSS
-  if (gSelection == iWZSelec){
-    if (gIsTTbar && genLeptons.size() < 2) return; // Dilepton selection for ttbar!!!
-  }
-  if(TNSelLeps >= 2 && passTrigger && passMETfilters){ // dilepton event, 2 leptons // && !isSS
+  if(TNSelLeps == 3 && passTrigger && passMETfilters){ // trilepton event with OSSF + l, passes trigger and MET filters
     // Deal with weights:
-    Float_t lepSF   = selLeptons.at(0).GetSF( 0)*selLeptons.at(1).GetSF( 0);
+    Float_t lepSF   = selLeptons.at(0).GetSF(0)*selLeptons.at(1).GetSF(0)*selLeptons.at(2).GetSF(0);
     Float_t ElecSF = 1; Float_t MuonSF = 1;
     Float_t ElecSFUp = 1; Float_t ElecSFDo = 1; Float_t MuonSFUp = 1; Float_t MuonSFDo = 1;
     Float_t stat = 0; 
@@ -159,40 +116,34 @@ void WZAnalysis::InsideLoop(){
     //https://twiki.cern.ch/twiki/bin/viewauth/CMS/MuonReferenceEffsRun2
     //Additional 1% for ID + 0.5% for Isolation + 0.5% single muon triggers
 
-    if(TChannel == iElec){
-      ElecSF   = selLeptons.at(0).GetSF( 0)*selLeptons.at(1).GetSF( 0);
-      ElecSFUp = selLeptons.at(0).GetSF( 1)*selLeptons.at(1).GetSF( 1);
-      ElecSFDo = selLeptons.at(0).GetSF(-1)*selLeptons.at(1).GetSF(-1);
+    if(TChannel == iElElEl){
+      ElecSF   = selLeptons.at(0).GetSF( 0)*selLeptons.at(1).GetSF( 0)*selLeptons.at(2).GetSF( 0);
+      ElecSFUp = selLeptons.at(0).GetSF( 1)*selLeptons.at(1).GetSF( 1)*selLeptons.at(2).GetSF( 1);
+      ElecSFDo = selLeptons.at(0).GetSF(-1)*selLeptons.at(1).GetSF(-1)*selLeptons.at(2).GetSF(-1);
       MuonSFUp = 1; MuonSFDo = 1; MuonSF = 1;
     }
-    else if(TChannel == iMuon){
-      MuonSF   = selLeptons.at(0).GetSF( 0)*selLeptons.at(1).GetSF( 0);
-      MuonSFUp = selLeptons.at(0).GetSF( 1)*selLeptons.at(1).GetSF( 1);
-      MuonSFDo = selLeptons.at(0).GetSF(-1)*selLeptons.at(1).GetSF(-1);
+    else if(TChannel == iMuMuMu){
+      MuonSF   = selLeptons.at(0).GetSF( 0)*selLeptons.at(1).GetSF( 0)*selLeptons.at(2).GetSF( 0);
+      MuonSFUp = selLeptons.at(0).GetSF( 1)*selLeptons.at(1).GetSF( 1)*selLeptons.at(2).GetSF( 1);
+      MuonSFDo = selLeptons.at(0).GetSF(-1)*selLeptons.at(1).GetSF(-1)*selLeptons.at(2).GetSF(-1);
       ElecSFUp = 1; ElecSFDo = 1; ElecSF = 1;
     }
-    else{
-      if(selLeptons.at(0).isMuon){
-        MuonSF   *= selLeptons.at(0).GetSF( 0);
-        MuonSFUp *= selLeptons.at(0).GetSF( 1);
-        MuonSFDo *= selLeptons.at(0).GetSF(-1);
-      }
-      else{
-        ElecSF   *= selLeptons.at(0).GetSF( 0);
-        ElecSFUp *= selLeptons.at(0).GetSF( 1);
-        ElecSFDo *= selLeptons.at(0).GetSF(-1);
-      }
-      if(selLeptons.at(1).isMuon){
-        MuonSF   *= selLeptons.at(1).GetSF( 0);
-        MuonSFUp *= selLeptons.at(1).GetSF( 1);
-        MuonSFDo *= selLeptons.at(1).GetSF(-1);
-      }
-      else{
-        ElecSF   *= selLeptons.at(1).GetSF( 0);
-        ElecSFUp *= selLeptons.at(1).GetSF( 1);
-        ElecSFDo *= selLeptons.at(1).GetSF(-1);
-      }
-    }
+		else{
+      MuonSFUp = 1; MuonSFDo = 1; MuonSF = 1;ElecSFUp = 1; ElecSFDo = 1; ElecSF = 1;
+			for (int i = 0; i <3; i ++){
+				if (selLeptons.at(i).isMuon){
+					MuonSF   *= selLeptons.at(i).GetSF( 0);
+					MuonSFUp *= selLeptons.at(i).GetSF( 1);
+					MuonSFDo *= selLeptons.at(i).GetSF(-1);				
+				}
+				else {
+					ElecSF   *= selLeptons.at(i).GetSF( 0);
+					ElecSFUp *= selLeptons.at(i).GetSF( 1);
+					ElecSFDo *= selLeptons.at(i).GetSF(-1);				
+				}
+			}
+		}
+
     TWeight             = NormWeight*ElecSF*MuonSF*TrigSF*PUSF;
     TWeight_ElecEffUp   = NormWeight*ElecSFUp*MuonSF*TrigSF*PUSF;
     TWeight_ElecEffDown = NormWeight*ElecSFDo*MuonSF*TrigSF*PUSF;
@@ -202,45 +153,30 @@ void WZAnalysis::InsideLoop(){
     TWeight_TrigDown   = NormWeight*lepSF*(TrigSF-TrigSFerr)*PUSF;
     TWeight_PUDown     = NormWeight*lepSF*TrigSF*PUSF_Up;
     TWeight_PUUp       = NormWeight*lepSF*TrigSF*PUSF_Down;
+
     if(gIsData) TWeight = 1;
     // Event Selection
     // ===================================================================================================================
-    if((selLeptons.at(0).p + selLeptons.at(1).p).M() > 20 && selLeptons.at(0).p.Pt() > 25){ // mll > 20 GeV, dilepton, leading lepton pT > 25 GeV
-      if(isSS) fHSSyields[gChannel][0] -> Fill(idilepton, TWeight);
-      else{    
-        fHyields[gChannel][0] -> Fill(idilepton, TWeight);
-        FillHistos(gChannel, idilepton);
-        FillDYHistos(gChannel);
-      }
 
-      if(TChannel == iElMu || (TMath::Abs((selLeptons.at(0).p + selLeptons.at(1).p).M() - 91) > 15)  ){ //  Z Veto in ee, µµ
-        if(isSS) fHSSyields[gChannel][0] -> Fill(iZVeto, TWeight);
-        else{      fHyields[gChannel][0] -> Fill(iZVeto, TWeight);
-          FillHistos(gChannel, iZVeto);}
+    if(TNSelLeps == 3 && TNOSSF > 0){ 
+			AssignWZLeptons();
+			if (lepZ1.Pt() > 25 && lepZ2.Pt() > 10 && lepW.Pt() > 25){//3 lepton, has OSSF, leptons assigned to W and Z
+	      fHyields[gChannel][0] -> Fill(itrilepton, TWeight);
+	      FillHistos(gChannel, itrilepton);
+	      FillDYHistos(gChannel);
+      
+      	if(TMath::Abs(TMll - nomZmass)< 15. && TMinMll > 4. && (lepZ1.p + lepZ2.p + lepW.p).M() > 100.  ){ //  Z window + exlcude low masses + M_3l selection 
+					fHyields[gChannel][0] -> Fill(ionZ, TWeight);
+      	  FillHistos(gChannel, ionZ);
 
-        if(TChannel == iElMu || TMET > 40){   // MET > 40 in ee, µµ
-          if(isSS) fHSSyields[gChannel][0] -> Fill(iMETcut, TWeight);
-          else{      fHyields[gChannel][0] -> Fill(iMETcut, TWeight);
-            FillHistos(gChannel, iMETcut);}
-
-          if(TNJets > 1){ //At least 2 jets
-            if(isSS) fHSSyields[gChannel][0] -> Fill(i2jets, TWeight);
-            else{      fHyields[gChannel][0] -> Fill(i2jets, TWeight);
-              FillHistos(gChannel, i2jets); }
-
-            if(TNBtags > 0){ // At least 1 b-tag
-              if(isSS) fHSSyields[gChannel][0] -> Fill(i1btag, TWeight);
-              else{      fHyields[gChannel][0] -> Fill(i1btag, TWeight);
-                FillHistos(gChannel, i1btag); }
-
+      	  if(TMET > 30.){   // MET > 30 always
+      	  	fHyields[gChannel][0] -> Fill(imet, TWeight);
+      	    FillHistos(gChannel, imet);
+      	    if(TNBtags == 0){ //Exactly 0 btags
+      	      fHyields[gChannel][0] -> Fill(i0btag, TWeight);
+      	      FillHistos(gChannel, i0btag);
+							fTree -> Fill();
             }
-          }
-        }
-      }
-      if(TChannel == iElMu){// || ((TMath::Abs((selLeptons.at(0).p + selLeptons.at(1).p).M() - 91) > 15))){
-        if(TChannel == iElMu || TMET > 40){   // MET > 40 in ee, µµ
-          if (TNBtags > 0 || TNBtagsBtagUp > 0 || TNBtagsBtagDown > 0 || TNBtagsMisTagUp > 0 || TNBtagsMisTagDown > 0 || TNBtagsJESUp > 0 || TNBtagsJESDown > 0){
-            fTree->Fill();
           }
         }
       }
@@ -250,8 +186,146 @@ void WZAnalysis::InsideLoop(){
 
 
 //#####################################################################
-// Functions
+// Initialize histograms/Minitrees
 //------------------------------------------------------------------
+void WZAnalysis::InitHistos(){
+  fhDummy = CreateH1F("fhDummy", "fhDummy", 1, 0, 2);
+  for(Int_t ch = 0; ch < nChannels; ch++){
+    fHyields[ch][0]     = CreateH1F("H_Yields_"+gChanLabel[ch],"", nLevels, -0.5, nLevels-0.5);
+    fHFiduYields[ch][0]     = CreateH1F("H_FiduYields_"+gChanLabel[ch],"", nLevels, -0.5, nLevels-0.5);
+  }
+  if(!makeHistos) return;
+  for(Int_t ch = 0; ch < nChannels; ch++){
+    for(Int_t cut = 0; cut < nLevels; cut++){
+      fHLHEweights[ch][cut][0]  = CreateH1F("H_LHEweights"  +gChanLabel[ch]+"_"+sCut[cut],"LHEweights", nWeights, -0.5, nWeights - 0.5);
+      fHMET[ch][cut][0]         = CreateH1F("H_MET_"        +gChanLabel[ch]+"_"+sCut[cut],"MET"       , 3000, 0,300);
+      fHLep0Eta[ch][cut][0]     = CreateH1F("H_Lep0Eta_"    +gChanLabel[ch]+"_"+sCut[cut],"Lep0Eta"   , 50  ,0 ,2.5);
+      fHLep1Eta[ch][cut][0]     = CreateH1F("H_Lep1Eta_"    +gChanLabel[ch]+"_"+sCut[cut],"Lep1Eta"   , 50  ,0 ,2.5);
+      fHDelLepPhi[ch][cut][0]   = CreateH1F("H_DelLepPhi_"  +gChanLabel[ch]+"_"+sCut[cut],"DelLepPhi" , 100, -3.2, 3.2);
+      fHHT[ch][cut][0]          = CreateH1F("H_HT_"         +gChanLabel[ch]+"_"+sCut[cut],"HT"        , 4700,30,500);
+      fHJet0Eta[ch][cut][0]     = CreateH1F("H_Jet0Eta_"  +gChanLabel[ch]+"_"+sCut[cut],"Jet0Eta"   , 50,0,2.5);
+      fHJet1Eta[ch][cut][0]     = CreateH1F("H_Jet1Eta_"  +gChanLabel[ch]+"_"+sCut[cut],"Jet1Eta"   , 50,0,2.5);
+      fHDYInvMass[ch][cut][0]     = CreateH1F("H_DY_InvMass_"    +gChanLabel[ch]+"_"+sCut[cut],"InvMass"   ,  300,  0., 300.);
+      fHInvMass[ch][cut][0]       = CreateH1F("H_InvMass_"    +gChanLabel[ch]+"_"+sCut[cut],"InvMass"   ,  300,  0., 300.);
+      fHInvMass2[ch][cut][0]      = CreateH1F("H_InvMass2_"   +gChanLabel[ch]+"_"+sCut[cut],"InvMass2"  ,  400, 70., 110.);
+      fHNBtagsNJets[ch][cut][0]   = CreateH1F("H_NBtagsNJets_"+gChanLabel[ch]+"_"+sCut[cut]  ,"NBtagsNJets"   ,15 , -0.5, 14.5);
+      fHNJets[ch][cut][0]       = CreateH1F("H_NJets_"      +gChanLabel[ch]+"_"+sCut[cut],"NJets"     , 8 ,-0.5, 7.5);
+      fHNBtagJets[ch][cut][0]   = CreateH1F("H_NBtagJets_"  +gChanLabel[ch]+"_"+sCut[cut],"NBtagJets" , 4 ,-0.5, 3.5);
+      fHJet0Pt[ch][cut][0]      = CreateH1F("H_Jet0Pt_"     +gChanLabel[ch]+"_"+sCut[cut],"Jet0Pt"    , 2700,30,300);
+      fHJet1Pt[ch][cut][0]      = CreateH1F("H_Jet1Pt_"     +gChanLabel[ch]+"_"+sCut[cut],"Jet1Pt"    , 2200,30,250);
+      fHDiLepPt[ch][cut][0]     = CreateH1F("H_DiLepPt_"    +gChanLabel[ch]+"_"+sCut[cut],"DiLepPt"   , 1600,20,180);
+      fHLep0Pt[ch][cut][0]      = CreateH1F("H_Lep0Pt_"     +gChanLabel[ch]+"_"+sCut[cut],"Lep0Pt"    , 1800,20,200);
+      fHLep1Pt[ch][cut][0]      = CreateH1F("H_Lep1Pt_"     +gChanLabel[ch]+"_"+sCut[cut],"Lep1Pt"    , 1800,20,200);
+      fHLep0Iso[ch][cut][0]      = CreateH1F("H_Lep0Iso_"     +gChanLabel[ch]+"_"+sCut[cut],"Leading lepton RelIso"    , 50,0,0.15);
+      fHLep1Iso[ch][cut][0]      = CreateH1F("H_Lep1Iso_"     +gChanLabel[ch]+"_"+sCut[cut],"Subleading lepton RelIso"    , 50,0,0.15);
+      fHJetCSV[ch][cut][0]  = CreateH1F("H_JetCSV_" +gChanLabel[ch]+"_"+sCut[cut],"CSV" , 100,0, 1.0);
+      fHJet0CSV[ch][cut][0]  = CreateH1F("H_Jet0CSV_" +gChanLabel[ch]+"_"+sCut[cut],"Jet0CSV" , 100,0, 1.0);
+      fHJet1CSV[ch][cut][0]  = CreateH1F("H_Jet1CSV_" +gChanLabel[ch]+"_"+sCut[cut],"Jet1CSV" , 100,0, 1.0);
+      fHvertices[ch][cut][0]     = CreateH1F("H_Vtx_"+gChanLabel[ch]+"_"+sCut[cut],"", 51, -0.5, 50.5); 
+    }
+  }
+  for(Int_t ch = 0; ch < nChannels; ch++){
+    for(Int_t cut = 0; cut < nLevels; cut++){
+      for(Int_t sys = 1; sys < nSysts; sys++){
+        fHLHEweights[ch][cut][sys]  = CreateH1F("H_LHEweights"  +gChanLabel[ch]+"_"+sCut[cut]+"_"+gSys[sys],"LHEweights", nWeights, -0.5, nWeights - 0.5);
+        fHMET[ch][cut][sys]         = CreateH1F("H_MET_"        +gChanLabel[ch]+"_"+sCut[cut]+"_"+gSys[sys],"MET"       , 3000, 0,300);
+        fHLep0Eta[ch][cut][sys]     = CreateH1F("H_Lep0Eta_"    +gChanLabel[ch]+"_"+sCut[cut]+"_"+gSys[sys],"Lep0Eta"   , 50  ,0 ,2.5);
+        fHLep1Eta[ch][cut][sys]     = CreateH1F("H_Lep1Eta_"    +gChanLabel[ch]+"_"+sCut[cut]+"_"+gSys[sys],"Lep1Eta"   , 50  ,0 ,2.5);
+        fHDelLepPhi[ch][cut][sys]   = CreateH1F("H_DelLepPhi_"  +gChanLabel[ch]+"_"+sCut[cut]+"_"+gSys[sys],"DelLepPhi" , 100,-3.2, 3.2);
+        fHHT[ch][cut][sys]          = CreateH1F("H_HT_"         +gChanLabel[ch]+"_"+sCut[cut]+"_"+gSys[sys],"HT"        , 4700,30,500);
+        fHJet0Eta[ch][cut][sys]     = CreateH1F("H_Jet0Eta_"  +gChanLabel[ch]+"_"+sCut[cut]+"_"+gSys[sys],"Jet0Eta"   , 50,0,2.5);
+        fHJet1Eta[ch][cut][sys]     = CreateH1F("H_Jet1Eta_"  +gChanLabel[ch]+"_"+sCut[cut]+"_"+gSys[sys],"Jet1Eta"   , 50,0,2.5);
+        fHDYInvMass[ch][cut][sys]       = CreateH1F("H_DY_InvMass_"    +gChanLabel[ch]+"_"+sCut[cut]+"_"+gSys[sys],"InvMass"   ,  300,  0., 300.);
+        fHInvMass[ch][cut][sys]       = CreateH1F("H_InvMass_"    +gChanLabel[ch]+"_"+sCut[cut]+"_"+gSys[sys],"InvMass"   ,  300,  0., 300.);
+        fHInvMass2[ch][cut][sys]      = CreateH1F("H_InvMass2_"   +gChanLabel[ch]+"_"+sCut[cut]+"_"+gSys[sys],"InvMass2"  ,  400, 70., 110.);
+        fHNBtagsNJets[ch][cut][sys]   = CreateH1F("H_NBtagsNJets_"+gChanLabel[ch]+"_"+sCut[cut]+"_"+gSys[sys]  ,"NBtagsNJets"   ,15 , -0.5, 14.5);
+        fHNJets[ch][cut][sys]        = CreateH1F("H_NJets_"      +gChanLabel[ch]+"_"+sCut[cut]+"_"+gSys[sys],"NJets"     , 8 ,-0.5, 7.5);
+        fHNBtagJets[ch][cut][sys]    = CreateH1F("H_NBtagJets_"  +gChanLabel[ch]+"_"+sCut[cut]+"_"+gSys[sys],"NBtagJets" , 4 ,-0.5, 3.5);
+        fHJet0Pt[ch][cut][sys]       = CreateH1F("H_Jet0Pt_"     +gChanLabel[ch]+"_"+sCut[cut]+"_"+gSys[sys],"Jet0Pt"    , 2700,30,300);
+        fHJet1Pt[ch][cut][sys]       = CreateH1F("H_Jet1Pt_"     +gChanLabel[ch]+"_"+sCut[cut]+"_"+gSys[sys],"Jet1Pt"    , 2200,30,250);
+        fHDiLepPt[ch][cut][sys]      = CreateH1F("H_DiLepPt_"    +gChanLabel[ch]+"_"+sCut[cut]+"_"+gSys[sys],"DiLepPt"   , 1600,20,180);
+        fHLep0Pt[ch][cut][sys]       = CreateH1F("H_Lep0Pt_"     +gChanLabel[ch]+"_"+sCut[cut]+"_"+gSys[sys],"Lep0Pt"    , 1800,20,200);
+        fHLep1Pt[ch][cut][sys]       = CreateH1F("H_Lep1Pt_"     +gChanLabel[ch]+"_"+sCut[cut]+"_"+gSys[sys],"Lep1Pt"    , 1800,20,200);
+        fHLep0Iso[ch][cut][sys]       = CreateH1F("H_Lep0Iso_"     +gChanLabel[ch]+"_"+sCut[cut]+"_"+gSys[sys],"RelIso"    , 50,0,0.15);
+        fHLep1Iso[ch][cut][sys]       = CreateH1F("H_Lep1Iso_"     +gChanLabel[ch]+"_"+sCut[cut]+"_"+gSys[sys],"RelIso"    , 50,0,0.15);
+        fHJetCSV[ch][cut][sys]       = CreateH1F("H_JetCSV_AllJets_" +gChanLabel[ch]+"_"+sCut[cut]+"_"+gSys[sys],"CSV" , 100,0, 1.0);
+        fHJet0CSV[ch][cut][sys]       = CreateH1F("H_Jet0CSV_" +gChanLabel[ch]+"_"+sCut[cut]+"_"+gSys[sys],"Jet0CSV" , 100,0, 1.0);
+        fHJet1CSV[ch][cut][sys]       = CreateH1F("H_Jet1CSV_" +gChanLabel[ch]+"_"+sCut[cut]+"_"+gSys[sys],"Jet1CSV" , 100,0, 1.0);
+        fHvertices[ch][cut][sys]     = CreateH1F("H_Vtx_"+gChanLabel[ch]+"_"+sCut[cut]+"_"+gSys[sys],"", 51, -0.5, 50.5); 
+      }
+    }
+  }
+}
+
+void WZAnalysis::SetLeptonVariables(){
+  fTree->Branch("TNVetoLeps",     &TNVetoLeps,     "TNVetoLeps/I");
+  fTree->Branch("TNSelLeps",     &TNSelLeps,     "TNSelLeps/I");
+  fTree->Branch("TLep_Pt",     TLep_Pt,     "TLep_Pt[TNSelLeps]/F");
+  fTree->Branch("TLep_Eta",     TLep_Eta,     "TLep_Eta[TNSelLeps]/F");
+  fTree->Branch("TLep_Phi",     TLep_Phi,     "TLep_Phi[TNSelLeps]/F");
+  fTree->Branch("TLep_E" ,     TLep_E ,     "TLep_E[TNSelLeps]/F");
+  fTree->Branch("TLep_Charge",  TLep_Charge, "TLep_Charge[TNSelLeps]/F");
+  fTree->Branch("TChannel",      &TChannel,      "TChannel/I");
+  fTree->Branch("TMll",        &TMll,      "TMll/F");
+  fTree->Branch("TNOSSF",      &TNOSSF,      "TNOSSF/I");
+  fTree->Branch("TMinMll",      &TMinMll,      "TMinMll/F");
+}
+
+void WZAnalysis::SetJetVariables(){
+  fTree->Branch("TNJets",           &TNJets,         "TNJets/I");
+  fTree->Branch("TNBtags",       &TNBtags,     "TNBtags/I");
+  fTree->Branch("TJet_isBJet",       TJet_isBJet,       "TJet_isBJet[TNJets]/I");
+  fTree->Branch("TJet_Pt",           TJet_Pt,           "TJet_Pt[TNJets]/F");
+  fTree->Branch("TJet_Eta",           TJet_Eta,           "TJet_Eta[TNJets]/F");
+  fTree->Branch("TJet_Phi",           TJet_Phi,           "TJet_Phi[TNJets]/F");
+  fTree->Branch("TJet_E",            TJet_E,            "TJet_E[TNJets]/F");
+
+  fTree->Branch("TNJetsJESUp",           &TNJetsJESUp,         "TNJetsJESUp/I");
+  fTree->Branch("TNJetsJESDown",           &TNJetsJESDown,         "TNJetsJESDown/I");
+  fTree->Branch("TNJetsJERUp",           &TNJetsJERUp,         "TNJetsJERUp/I");
+
+  fTree->Branch("TNBtagsBtagUp",     &TNBtagsBtagUp,   "TNBtagsBtagUp/I");
+  fTree->Branch("TNBtagsBtagDown",   &TNBtagsBtagDown, "TNBtagsBtagDown/I");
+  fTree->Branch("TNBtagsMisTagUp",     &TNBtagsMisTagUp,   "TNBtagsMisTagUp/I");
+  fTree->Branch("TNBtagsMisTagDown",   &TNBtagsMisTagDown, "TNBtagsMisTagDown/I");
+
+  fTree->Branch("TNBtagsJESUp",   &TNBtagsJESUp, "TNBtagsJESUp/I");
+  fTree->Branch("TNBtagsJESDown",  &TNBtagsJESDown, "TNBtagsJESDown/I");
+
+  fTree->Branch("TJetJESUp_Pt",      TJetJESUp_Pt,      "TJetJESUp_Pt[TNJetsJESUp]/F");
+  fTree->Branch("TJetJESDown_Pt",    TJetJESDown_Pt,    "TJetJESDown_Pt[TNJetsJESDown]/F");
+  fTree->Branch("TJetJER_Pt",        TJetJER_Pt,        "TJetJER_Pt[TNJetsJERUp]/F");
+
+  fTree->Branch("THT",          &THT,          "THT/F");
+  fTree->Branch("THTJESUp",     &THTJESUp,     "THTJESUp/F");
+  fTree->Branch("THTJESDown",   &THTJESDown,   "THTJESDown/F");
+}
+
+void WZAnalysis::SetEventVariables(){
+  fTree->Branch("TWeight",      &TWeight,      "TWeight/F");
+  fTree->Branch("TWeight_LepEffUp",      &TWeight_LepEffUp,      "TWeight_LepEffUp/F");
+  fTree->Branch("TWeight_LepEffDown",    &TWeight_LepEffDown,    "TWeight_LepEffDown/F");
+  fTree->Branch("TWeight_ElecEffUp",      &TWeight_ElecEffUp,      "TWeight_ElecEffUp/F");
+  fTree->Branch("TWeight_ElecEffDown",    &TWeight_ElecEffDown,    "TWeight_ElecEffDown/F");
+  fTree->Branch("TWeight_MuonEffUp",      &TWeight_MuonEffUp,      "TWeight_MuonEffUp/F");
+  fTree->Branch("TWeight_MuonEffDown",    &TWeight_MuonEffDown,    "TWeight_MuonEffDown/F");
+  fTree->Branch("TWeight_TrigUp",        &TWeight_TrigUp,        "TWeight_TrigUp/F");
+  fTree->Branch("TWeight_TrigDown",      &TWeight_TrigDown,      "TWeight_TrigDown/F");
+  fTree->Branch("TWeight_PUUp",        &TWeight_PUUp,        "TWeight_PUUp/F");
+  fTree->Branch("TWeight_PUDown",        &TWeight_PUDown,        "TWeight_PUDown/F");
+
+  fTree->Branch("TLHEWeight",        TLHEWeight,         "TLHEWeight[254]/F");
+  fTree->Branch("TMET",         &TMET,         "TMET/F");
+  fTree->Branch("TGenMET",         &TGenMET,         "TGenMET/F");
+  fTree->Branch("TMET_Phi",     &TMET_Phi,     "TMET_Phi/F");
+  fTree->Branch("TMETJESUp",    &TMETJESUp,    "TMETJESUp/F");
+  fTree->Branch("TMETJESDown",  &TMETJESDown,  "TMETJESDown/F");
+}
+
+//#####################################################################
+// Get Variables
+//------------------------------------------------------------------
+
 void WZAnalysis::GetLeptonVariables(std::vector<Lepton> selLeptons, std::vector<Lepton> VetoLeptons){
   TNSelLeps = selLeptons.size();
   Int_t nVetoLeptons = VetoLeptons.size();
@@ -263,23 +337,32 @@ void WZAnalysis::GetLeptonVariables(std::vector<Lepton> selLeptons, std::vector<
     TLep_E[i]      = selLeptons.at(i).E();    
     TLep_Charge[i] = selLeptons.at(i).charge;    
   }
-  if(TNSelLeps < 2) gChannel = -1;
-  else if(selLeptons.at(0).isMuon && selLeptons.at(1).isElec) gChannel = iElMu;
-  else if(selLeptons.at(0).isElec && selLeptons.at(1).isMuon) gChannel = iElMu;
-  else if(selLeptons.at(0).isMuon && selLeptons.at(1).isMuon) gChannel = iMuon;
-  else if(selLeptons.at(0).isElec && selLeptons.at(1).isElec) gChannel = iElec;
-  if(TNSelLeps > 1) TMll = (selLeptons.at(0).p + selLeptons.at(1).p).M();      
-  TChannel = gChannel;
-  TIsSS = isSS;
-  gChannel = gChannel -1; // gchannel used for chan index of histograms
-  
-  bool TIsOSDilep = false;
-  if (TNSelLeps >= 2)
-    TIsOSDilep = passTrigger && passMETfilters && (!isSS) && ((selLeptons.at(0).p + selLeptons.at(1).p).M() > 20) && selLeptons.at(0).p.Pt() > 25;
-  else
-    TIsOSDilep = false;
+	//Require exactly 3 leptons
+  if(TNSelLeps != 3) gChannel = -1;
+	//Charge compatibility with WZ production
+	else if(TMath::Abs(selLeptons.at(0).charge + selLeptons.at(1).charge + selLeptons.at(2).charge) != 1) gChannel = -1;
+	//Combinatory of posible final leptons
+  else if(selLeptons.at(0).isMuon && selLeptons.at(1).isMuon && selLeptons.at(2).isMuon) gChannel = iMuMuMu;
+  else if(selLeptons.at(0).isMuon && selLeptons.at(1).isMuon && selLeptons.at(2).isElec) gChannel = iElMuMu;
+  else if(selLeptons.at(0).isMuon && selLeptons.at(1).isElec && selLeptons.at(2).isMuon) gChannel = iElMuMu;
+  else if(selLeptons.at(0).isMuon && selLeptons.at(1).isElec && selLeptons.at(2).isElec) gChannel = iElElMu;
+  else if(selLeptons.at(0).isElec && selLeptons.at(1).isMuon && selLeptons.at(2).isMuon) gChannel = iElMuMu;
+  else if(selLeptons.at(0).isElec && selLeptons.at(1).isMuon && selLeptons.at(2).isElec) gChannel = iElElMu;
+  else if(selLeptons.at(0).isElec && selLeptons.at(1).isElec && selLeptons.at(2).isMuon) gChannel = iElElMu;
+  else if(selLeptons.at(0).isElec && selLeptons.at(1).isElec && selLeptons.at(2).isElec) gChannel = iElElEl;
+	TMinMll = 100000;
+	TNOSSF = 0;
+	for(Int_t i = 0; i < TNSelLeps; i++){
+		for(Int_t j = i+1; j < TNSelLeps; j++){
+			if (selLeptons.at(j).isMuon && selLeptons.at(i).isMuon && selLeptons.at(i).charge*selLeptons.at(j).charge == -1) 					TNOSSF++;
+			Float_t hypMll = (selLeptons.at(j).p + selLeptons.at(i).p).M();
+			if (hypMll < TMinMll) TMinMll = hypMll;
+		}
+	}
 
-  SetParam("TIsOSDilep",TIsOSDilep);
+
+  TChannel = gChannel;
+  gChannel = gChannel -1; // gchannel used for chan index of histograms
 }
 
 void WZAnalysis::GetJetVariables(std::vector<Jet> selJets, std::vector<Jet> cleanedJets15, Float_t ptCut){
@@ -350,95 +433,25 @@ void WZAnalysis::GetMET(){
   if(gIsLHE)  for(Int_t i = 0; i < Get<Int_t>("nLHEweight"); i++)   TLHEWeight[i] = Get<Float_t>("LHEweight_wgt", i);
 }
 
-void WZAnalysis::InitHistos(){
-  fhDummy = CreateH1F("fhDummy", "fhDummy", 1, 0, 2);
-  for(Int_t ch = 0; ch < nChannels; ch++){
-    fHyields[ch][0]     = CreateH1F("H_Yields_"+gChanLabel[ch],"", nLevels, -0.5, nLevels-0.5);
-    fHFiduYields[ch][0]     = CreateH1F("H_FiduYields_"+gChanLabel[ch],"", nLevels, -0.5, nLevels-0.5);
-    fHSSyields[ch][0]   = CreateH1F("H_SSYields_"+gChanLabel[ch],"", nLevels, -0.5, nLevels-0.5);
-  }
-  if(!makeHistos) return;
-  for(Int_t ch = 0; ch < nChannels; ch++){
-    for(Int_t cut = 0; cut < nLevels; cut++){
-      fHLHEweights[ch][cut][0]  = CreateH1F("H_LHEweights"  +gChanLabel[ch]+"_"+sCut[cut],"LHEweights", nWeights, -0.5, nWeights - 0.5);
-      fHMET[ch][cut][0]         = CreateH1F("H_MET_"        +gChanLabel[ch]+"_"+sCut[cut],"MET"       , 3000, 0,300);
-      fHLep0Eta[ch][cut][0]     = CreateH1F("H_Lep0Eta_"    +gChanLabel[ch]+"_"+sCut[cut],"Lep0Eta"   , 50  ,0 ,2.5);
-      fHLep1Eta[ch][cut][0]     = CreateH1F("H_Lep1Eta_"    +gChanLabel[ch]+"_"+sCut[cut],"Lep1Eta"   , 50  ,0 ,2.5);
-      fHDelLepPhi[ch][cut][0]   = CreateH1F("H_DelLepPhi_"  +gChanLabel[ch]+"_"+sCut[cut],"DelLepPhi" , 100, -3.2, 3.2);
-      fHHT[ch][cut][0]          = CreateH1F("H_HT_"         +gChanLabel[ch]+"_"+sCut[cut],"HT"        , 4700,30,500);
-      fHJet0Eta[ch][cut][0]     = CreateH1F("H_Jet0Eta_"  +gChanLabel[ch]+"_"+sCut[cut],"Jet0Eta"   , 50,0,2.5);
-      fHJet1Eta[ch][cut][0]     = CreateH1F("H_Jet1Eta_"  +gChanLabel[ch]+"_"+sCut[cut],"Jet1Eta"   , 50,0,2.5);
-      fHDYInvMass[ch][cut][0]     = CreateH1F("H_DY_InvMass_"    +gChanLabel[ch]+"_"+sCut[cut],"InvMass"   ,  300,  0., 300.);
-      fHInvMass[ch][cut][0]       = CreateH1F("H_InvMass_"    +gChanLabel[ch]+"_"+sCut[cut],"InvMass"   ,  300,  0., 300.);
-      fHInvMass2[ch][cut][0]      = CreateH1F("H_InvMass2_"   +gChanLabel[ch]+"_"+sCut[cut],"InvMass2"  ,  400, 70., 110.);
-      fHNBtagsNJets[ch][cut][0]   = CreateH1F("H_NBtagsNJets_"+gChanLabel[ch]+"_"+sCut[cut]  ,"NBtagsNJets"   ,15 , -0.5, 14.5);
-      fHNJets[ch][cut][0]       = CreateH1F("H_NJets_"      +gChanLabel[ch]+"_"+sCut[cut],"NJets"     , 8 ,-0.5, 7.5);
-      fHNBtagJets[ch][cut][0]   = CreateH1F("H_NBtagJets_"  +gChanLabel[ch]+"_"+sCut[cut],"NBtagJets" , 4 ,-0.5, 3.5);
-      fHJet0Pt[ch][cut][0]      = CreateH1F("H_Jet0Pt_"     +gChanLabel[ch]+"_"+sCut[cut],"Jet0Pt"    , 2700,30,300);
-      fHJet1Pt[ch][cut][0]      = CreateH1F("H_Jet1Pt_"     +gChanLabel[ch]+"_"+sCut[cut],"Jet1Pt"    , 2200,30,250);
-      fHDiLepPt[ch][cut][0]     = CreateH1F("H_DiLepPt_"    +gChanLabel[ch]+"_"+sCut[cut],"DiLepPt"   , 1600,20,180);
-      fHLep0Pt[ch][cut][0]      = CreateH1F("H_Lep0Pt_"     +gChanLabel[ch]+"_"+sCut[cut],"Lep0Pt"    , 1800,20,200);
-      fHLep1Pt[ch][cut][0]      = CreateH1F("H_Lep1Pt_"     +gChanLabel[ch]+"_"+sCut[cut],"Lep1Pt"    , 1800,20,200);
-      fHLep0Iso[ch][cut][0]      = CreateH1F("H_Lep0Iso_"     +gChanLabel[ch]+"_"+sCut[cut],"Leading lepton RelIso"    , 50,0,0.15);
-      fHLep1Iso[ch][cut][0]      = CreateH1F("H_Lep1Iso_"     +gChanLabel[ch]+"_"+sCut[cut],"Subleading lepton RelIso"    , 50,0,0.15);
-      fHJetCSV[ch][cut][0]  = CreateH1F("H_JetCSV_" +gChanLabel[ch]+"_"+sCut[cut],"CSV" , 100,0, 1.0);
-      fHJet0CSV[ch][cut][0]  = CreateH1F("H_Jet0CSV_" +gChanLabel[ch]+"_"+sCut[cut],"Jet0CSV" , 100,0, 1.0);
-      fHJet1CSV[ch][cut][0]  = CreateH1F("H_Jet1CSV_" +gChanLabel[ch]+"_"+sCut[cut],"Jet1CSV" , 100,0, 1.0);
-      fHvertices[ch][cut][0]     = CreateH1F("H_Vtx_"+gChanLabel[ch]+"_"+sCut[cut],"", 51, -0.5, 50.5); 
-    }
-  }
-  for(Int_t ch = 0; ch < nChannels; ch++){
-    for(Int_t cut = 0; cut < nLevels; cut++){
-      for(Int_t sys = 1; sys < nSysts; sys++){
-        fHLHEweights[ch][cut][sys]  = CreateH1F("H_LHEweights"  +gChanLabel[ch]+"_"+sCut[cut]+"_"+gSys[sys],"LHEweights", nWeights, -0.5, nWeights - 0.5);
-        fHMET[ch][cut][sys]         = CreateH1F("H_MET_"        +gChanLabel[ch]+"_"+sCut[cut]+"_"+gSys[sys],"MET"       , 3000, 0,300);
-        fHLep0Eta[ch][cut][sys]     = CreateH1F("H_Lep0Eta_"    +gChanLabel[ch]+"_"+sCut[cut]+"_"+gSys[sys],"Lep0Eta"   , 50  ,0 ,2.5);
-        fHLep1Eta[ch][cut][sys]     = CreateH1F("H_Lep1Eta_"    +gChanLabel[ch]+"_"+sCut[cut]+"_"+gSys[sys],"Lep1Eta"   , 50  ,0 ,2.5);
-        fHDelLepPhi[ch][cut][sys]   = CreateH1F("H_DelLepPhi_"  +gChanLabel[ch]+"_"+sCut[cut]+"_"+gSys[sys],"DelLepPhi" , 100,-3.2, 3.2);
-        fHHT[ch][cut][sys]          = CreateH1F("H_HT_"         +gChanLabel[ch]+"_"+sCut[cut]+"_"+gSys[sys],"HT"        , 4700,30,500);
-        fHJet0Eta[ch][cut][sys]     = CreateH1F("H_Jet0Eta_"  +gChanLabel[ch]+"_"+sCut[cut]+"_"+gSys[sys],"Jet0Eta"   , 50,0,2.5);
-        fHJet1Eta[ch][cut][sys]     = CreateH1F("H_Jet1Eta_"  +gChanLabel[ch]+"_"+sCut[cut]+"_"+gSys[sys],"Jet1Eta"   , 50,0,2.5);
-        fHDYInvMass[ch][cut][sys]       = CreateH1F("H_DY_InvMass_"    +gChanLabel[ch]+"_"+sCut[cut]+"_"+gSys[sys],"InvMass"   ,  300,  0., 300.);
-        fHInvMass[ch][cut][sys]       = CreateH1F("H_InvMass_"    +gChanLabel[ch]+"_"+sCut[cut]+"_"+gSys[sys],"InvMass"   ,  300,  0., 300.);
-        fHInvMass2[ch][cut][sys]      = CreateH1F("H_InvMass2_"   +gChanLabel[ch]+"_"+sCut[cut]+"_"+gSys[sys],"InvMass2"  ,  400, 70., 110.);
-        fHNBtagsNJets[ch][cut][sys]   = CreateH1F("H_NBtagsNJets_"+gChanLabel[ch]+"_"+sCut[cut]+"_"+gSys[sys]  ,"NBtagsNJets"   ,15 , -0.5, 14.5);
-        fHNJets[ch][cut][sys]        = CreateH1F("H_NJets_"      +gChanLabel[ch]+"_"+sCut[cut]+"_"+gSys[sys],"NJets"     , 8 ,-0.5, 7.5);
-        fHNBtagJets[ch][cut][sys]    = CreateH1F("H_NBtagJets_"  +gChanLabel[ch]+"_"+sCut[cut]+"_"+gSys[sys],"NBtagJets" , 4 ,-0.5, 3.5);
-        fHJet0Pt[ch][cut][sys]       = CreateH1F("H_Jet0Pt_"     +gChanLabel[ch]+"_"+sCut[cut]+"_"+gSys[sys],"Jet0Pt"    , 2700,30,300);
-        fHJet1Pt[ch][cut][sys]       = CreateH1F("H_Jet1Pt_"     +gChanLabel[ch]+"_"+sCut[cut]+"_"+gSys[sys],"Jet1Pt"    , 2200,30,250);
-        fHDiLepPt[ch][cut][sys]      = CreateH1F("H_DiLepPt_"    +gChanLabel[ch]+"_"+sCut[cut]+"_"+gSys[sys],"DiLepPt"   , 1600,20,180);
-        fHLep0Pt[ch][cut][sys]       = CreateH1F("H_Lep0Pt_"     +gChanLabel[ch]+"_"+sCut[cut]+"_"+gSys[sys],"Lep0Pt"    , 1800,20,200);
-        fHLep1Pt[ch][cut][sys]       = CreateH1F("H_Lep1Pt_"     +gChanLabel[ch]+"_"+sCut[cut]+"_"+gSys[sys],"Lep1Pt"    , 1800,20,200);
-        fHLep0Iso[ch][cut][sys]       = CreateH1F("H_Lep0Iso_"     +gChanLabel[ch]+"_"+sCut[cut]+"_"+gSys[sys],"RelIso"    , 50,0,0.15);
-        fHLep1Iso[ch][cut][sys]       = CreateH1F("H_Lep1Iso_"     +gChanLabel[ch]+"_"+sCut[cut]+"_"+gSys[sys],"RelIso"    , 50,0,0.15);
-        fHJetCSV[ch][cut][sys]       = CreateH1F("H_JetCSV_AllJets_" +gChanLabel[ch]+"_"+sCut[cut]+"_"+gSys[sys],"CSV" , 100,0, 1.0);
-        fHJet0CSV[ch][cut][sys]       = CreateH1F("H_Jet0CSV_" +gChanLabel[ch]+"_"+sCut[cut]+"_"+gSys[sys],"Jet0CSV" , 100,0, 1.0);
-        fHJet1CSV[ch][cut][sys]       = CreateH1F("H_Jet1CSV_" +gChanLabel[ch]+"_"+sCut[cut]+"_"+gSys[sys],"Jet1CSV" , 100,0, 1.0);
-        fHvertices[ch][cut][sys]     = CreateH1F("H_Vtx_"+gChanLabel[ch]+"_"+sCut[cut]+"_"+gSys[sys],"", 51, -0.5, 50.5); 
-      }
-    }
-  }
-}
+//#####################################################################
+// Fill histograms/Minitrees
+//------------------------------------------------------------------
 
 void WZAnalysis::FillDYHistos(Int_t ch){
   Int_t sys = 0;
   Int_t cut;
   Float_t EventWeight = TWeight;
-  cut = idilepton;
+  cut = itrilepton;
   fHDYInvMass[ch][cut][sys]       -> Fill(TMll, EventWeight);
-  cut = iZVeto;
+  cut = ionZ;
   fHDYInvMass[ch][cut][sys]       -> Fill(TMll, EventWeight);
   //  if(TMET > 40){
-  cut = iMETcut;
+  cut = imet;
   fHDYInvMass[ch][cut][sys]       -> Fill(TMll, EventWeight);
   //  }
-  if(TNJets > 1){
-    cut = i2jets;
+  if(TNBtags == 0){
+    cut = i0btag;
     fHDYInvMass[ch][cut][sys]       -> Fill(TMll, EventWeight);
-    if(TNBtags > 0){
-      cut = i1btag;
-      fHDYInvMass[ch][cut][sys]       -> Fill(TMll, EventWeight);
-    }
   }
 }
 
@@ -482,70 +495,9 @@ void WZAnalysis::FillHistos(Int_t ch, Int_t cut){
   if(TNJets == 4) fHNBtagsNJets[ch][cut][sys]   -> Fill(TNBtags+10, EventWeight);
 }
 
-void WZAnalysis::SetLeptonVariables(){
-  fTree->Branch("TNVetoLeps",     &TNVetoLeps,     "TNVetoLeps/I");
-  fTree->Branch("TNSelLeps",     &TNSelLeps,     "TNSelLeps/I");
-  fTree->Branch("TLep_Pt",     TLep_Pt,     "TLep_Pt[TNSelLeps]/F");
-  fTree->Branch("TLep_Eta",     TLep_Eta,     "TLep_Eta[TNSelLeps]/F");
-  fTree->Branch("TLep_Phi",     TLep_Phi,     "TLep_Phi[TNSelLeps]/F");
-  fTree->Branch("TLep_E" ,     TLep_E ,     "TLep_E[TNSelLeps]/F");
-  fTree->Branch("TLep_Charge",  TLep_Charge, "TLep_Charge[TNSelLeps]/F");
-  fTree->Branch("TChannel",      &TChannel,      "TChannel/I");
-  fTree->Branch("TIsSS",      &TIsSS,      "TIsSS/B");
-  fTree->Branch("TMll",      &TMll,      "TMll/F");
-}
-
-void WZAnalysis::SetJetVariables(){
-  fTree->Branch("TNJets",           &TNJets,         "TNJets/I");
-  fTree->Branch("TNBtags",       &TNBtags,     "TNBtags/I");
-  fTree->Branch("TJet_isBJet",       TJet_isBJet,       "TJet_isBJet[TNJets]/I");
-  fTree->Branch("TJet_Pt",           TJet_Pt,           "TJet_Pt[TNJets]/F");
-  fTree->Branch("TJet_Eta",           TJet_Eta,           "TJet_Eta[TNJets]/F");
-  fTree->Branch("TJet_Phi",           TJet_Phi,           "TJet_Phi[TNJets]/F");
-  fTree->Branch("TJet_E",            TJet_E,            "TJet_E[TNJets]/F");
-
-  fTree->Branch("TNJetsJESUp",           &TNJetsJESUp,         "TNJetsJESUp/I");
-  fTree->Branch("TNJetsJESDown",           &TNJetsJESDown,         "TNJetsJESDown/I");
-  fTree->Branch("TNJetsJERUp",           &TNJetsJERUp,         "TNJetsJERUp/I");
-
-  fTree->Branch("TNBtagsBtagUp",     &TNBtagsBtagUp,   "TNBtagsBtagUp/I");
-  fTree->Branch("TNBtagsBtagDown",   &TNBtagsBtagDown, "TNBtagsBtagDown/I");
-  fTree->Branch("TNBtagsMisTagUp",     &TNBtagsMisTagUp,   "TNBtagsMisTagUp/I");
-  fTree->Branch("TNBtagsMisTagDown",   &TNBtagsMisTagDown, "TNBtagsMisTagDown/I");
-
-  fTree->Branch("TNBtagsJESUp",   &TNBtagsJESUp, "TNBtagsJESUp/I");
-  fTree->Branch("TNBtagsJESDown",  &TNBtagsJESDown, "TNBtagsJESDown/I");
-
-  fTree->Branch("TJetJESUp_Pt",      TJetJESUp_Pt,      "TJetJESUp_Pt[TNJetsJESUp]/F");
-  fTree->Branch("TJetJESDown_Pt",    TJetJESDown_Pt,    "TJetJESDown_Pt[TNJetsJESDown]/F");
-  fTree->Branch("TJetJER_Pt",        TJetJER_Pt,        "TJetJER_Pt[TNJetsJERUp]/F");
-
-  fTree->Branch("THT",          &THT,          "THT/F");
-  fTree->Branch("THTJESUp",     &THTJESUp,     "THTJESUp/F");
-  fTree->Branch("THTJESDown",   &THTJESDown,   "THTJESDown/F");
-}
-
-void WZAnalysis::SetEventVariables(){
-  fTree->Branch("TWeight",      &TWeight,      "TWeight/F");
-  fTree->Branch("TWeight_LepEffUp",      &TWeight_LepEffUp,      "TWeight_LepEffUp/F");
-  fTree->Branch("TWeight_LepEffDown",    &TWeight_LepEffDown,    "TWeight_LepEffDown/F");
-  fTree->Branch("TWeight_ElecEffUp",      &TWeight_ElecEffUp,      "TWeight_ElecEffUp/F");
-  fTree->Branch("TWeight_ElecEffDown",    &TWeight_ElecEffDown,    "TWeight_ElecEffDown/F");
-  fTree->Branch("TWeight_MuonEffUp",      &TWeight_MuonEffUp,      "TWeight_MuonEffUp/F");
-  fTree->Branch("TWeight_MuonEffDown",    &TWeight_MuonEffDown,    "TWeight_MuonEffDown/F");
-  fTree->Branch("TWeight_TrigUp",        &TWeight_TrigUp,        "TWeight_TrigUp/F");
-  fTree->Branch("TWeight_TrigDown",      &TWeight_TrigDown,      "TWeight_TrigDown/F");
-  fTree->Branch("TWeight_PUUp",        &TWeight_PUUp,        "TWeight_PUUp/F");
-  fTree->Branch("TWeight_PUDown",        &TWeight_PUDown,        "TWeight_PUDown/F");
-
-  fTree->Branch("TLHEWeight",        TLHEWeight,         "TLHEWeight[254]/F");
-  fTree->Branch("TMET",         &TMET,         "TMET/F");
-  fTree->Branch("TGenMET",         &TGenMET,         "TGenMET/F");
-  fTree->Branch("TMET_Phi",     &TMET_Phi,     "TMET_Phi/F");
-  fTree->Branch("TMETJESUp",    &TMETJESUp,    "TMETJESUp/F");
-  fTree->Branch("TMETJESDown",  &TMETJESDown,  "TMETJESDown/F");
-}
-
+//#####################################################################
+// Additional lepton selection code
+//------------------------------------------------------------------
 
 bool WZAnalysis::lepMVA(Lepton& lep, TString wp)
 {
@@ -698,9 +650,40 @@ void WZAnalysis::makeLeptonCollections()
       if(lepMVA(lep, "VT")) selLeptonsLV.push_back(lep);
       if(lepMVA(lep, "M"))  selLeptonsLM.push_back(lep);
       if(lepMVA(lep, "L"))  vetoLeptonsLL.push_back(lep);
-    }
-  
+    } 
 }
 
+void WZAnalysis::AssignWZLeptons()
+{
+	Float_t dZmass = 100000.; 
+	Int_t indexZ1;
+	Int_t indexZ2;
+	for(Int_t i = 0; i < TNSelLeps; i++){
+		for(Int_t j = i+1; j < TNSelLeps; j++){
+			if (selLeptons.at(j).isMuon && selLeptons.at(i).isMuon && selLeptons.at(i).charge*selLeptons.at(j).charge == -1){
+				Float_t hypZmass = (selLeptons.at(j).p + selLeptons.at(i).p).M();
+				if (TMath::Abs(hypZmass-nomZmass) < dZmass){
+					dZmass = TMath::Abs(hypZmass-nomZmass);
+					TMll  = hypZmass;
+					indexZ1 = j;
+					indexZ2 = i;
+					if (selLeptons.at(j).Pt() > selLeptons.at(i).Pt()) {
+						lepZ1 = selLeptons.at(j);
+						lepZ2 = selLeptons.at(i); 
+					}
+					else{
+						lepZ1 = selLeptons.at(i);
+						lepZ2 = selLeptons.at(j);
+					}
+				}
+			}
+		}
+	}
+	for(Int_t i = 0; i < TNSelLeps; i++){
+		if (i != indexZ1 && i != indexZ2){
+			lepW = selLeptons.at(i);
+		}
+	}	
+}
 
 

--- a/packages/WZAnalysis/WZAnalysis.C
+++ b/packages/WZAnalysis/WZAnalysis.C
@@ -547,13 +547,9 @@ void WZAnalysis::SetEventVariables(){
 }
 
 
-Bool_t LeptonSelector::isGoodLepton(Lepton lep){
-}
-
-
-void WZAnalysis::lepMVA(Lepton& lep, TString wp)
+bool WZAnalysis::lepMVA(Lepton& lep, TString wp)
 {
-  if(wp=="LV")
+/*  if(wp=="LV")
     {
       // 	Tight muons for multilepton ttH Analysis:
       // abs(eta)<0.4, Pt>15, abs(dxy)<0.05cm, abs(dz)<0.1cm, SIP3D<8, Imini<0.4,
@@ -568,8 +564,8 @@ void WZAnalysis::lepMVA(Lepton& lep, TString wp)
       // Deltaphiin<(0.04,0.04,0.07),-0.05<1/E-1/p<(0.01,0.01,0.005)
       //
       if (lep.isMuon) {
-        if(abs(eta) >= 2.4)        return false;
-        if(pt < 10)                return false;
+        if(abs(lep.p.Eta()) >= 2.4)        return false;
+        if(lep.p.Pt() < 10)                return false;
         if(!getGoodVertex(iTight)) return false;
         if(!getSIPcut(8))          return false;
         if(!getminiRelIso(iTight)) return false;
@@ -578,8 +574,8 @@ void WZAnalysis::lepMVA(Lepton& lep, TString wp)
         if(MVATTH <= 0.90)         return false;
       }
       if (lep.isElec) {
-        if(abs(eta) <= 2.5)           return false;
-        if(pt <= 10)                  return false;
+        if(abs(lep.p.Eta()) <= 2.5)           return false;
+        if(lep.p.Pt() <= 10)                  return false;
         if(!getGoodVertex(iTight))    return false;
         if(!getSIPcut(8))             return false;
         if(!getminiRelIso(iTight))    return false;
@@ -599,15 +595,15 @@ void WZAnalysis::lepMVA(Lepton& lep, TString wp)
       // ptratio, 1/E-1/p, deltaPhiin, deltaEtain, H/E, sigmaietaieta cuts
       //
       if (lep.isMuon) {
-        if(abs(eta) >= 2.4)          return false;
-        if(pt <= 5)                  return false;
+        if(abs(lep.p.Eta()) >= 2.4)          return false;
+        if(lep.p.Pt() <= 5)                  return false;
         if(!getGoodVertex(iLoose))  return false;
         if(!getSIPcut(8))           return false;
         if(!getminiRelIso(iLoose))  return false;
       }
       if (lep.isElec) {
-        if(abs(eta) >= 2.5)            return false;
-        if(pt <= 7)                    return false;
+        if(abs(lep.p.Eta()) >= 2.5)            return false;
+        if(lep.p.Pt() <= 7)                    return false;
         if(!getGoodVertex(iLoose))    return false;
         if(!getSIPcut(8))             return false;
         if(!getminiRelIso(iLoose))    return false;
@@ -626,8 +622,8 @@ void WZAnalysis::lepMVA(Lepton& lep, TString wp)
       // w/o cut in ptratio) and, in this case too, with <0.3 jet CSV.
       //
       if (lep.isMuon) {
-        if(abs(eta) >= 2.4)          return false;
-        if(pt <= 10)                 return false;
+        if(abs(lep.p.Eta()) >= 2.4)          return false;
+        if(lep.p.Pt() <= 10)                 return false;
         if(!getGoodVertex(iMedium)) return false;
         if(!getSIPcut(8))           return false;
         if(!getminiRelIso(iLoose))  return false;
@@ -640,8 +636,8 @@ void WZAnalysis::lepMVA(Lepton& lep, TString wp)
         }
       }
       if (lep.isElec) {
-        if(abs(eta) >= 2.5)           return false;
-        if(pt > 10)                   return false;
+        if(abs(lep.p.Eta()) >= 2.5)           return false;
+        if(lep.p.Pt() > 10)                   return false;
         if(!getGoodVertex(iMedium))   return false;
         if(!getSIPcut(8))             return false;
         if(!getminiRelIso(iLoose))    return false;
@@ -654,11 +650,12 @@ void WZAnalysis::lepMVA(Lepton& lep, TString wp)
         }
       }
       return true;
-    }
+    }*/
+	return true;
 }
 
-void WZAnalysis::pogID(Lepton& lep, TString wp)
-{
+bool WZAnalysis::pogID(Lepton& lep, TString wp)
+{/*
   if(wp=="POGMain"){
     Bool_t passId; Bool_t passIso;
     
@@ -685,7 +682,7 @@ void WZAnalysis::pogID(Lepton& lep, TString wp)
     {
       
     }
-
+*/
   return true;
 }
 

--- a/packages/WZAnalysis/WZAnalysis.C
+++ b/packages/WZAnalysis/WZAnalysis.C
@@ -5,7 +5,7 @@ ClassImp(WZAnalysis);
 bool GreaterThan(float i, float j){ return (i > j);}
 
 WZAnalysis::WZAnalysis() : PAFChainItemSelector() {
-	//fTree = {0};
+  //fTree = {0};
   fhDummy = 0;
   passMETfilters = 0;
   passTrigger    = 0;
@@ -63,12 +63,12 @@ void WZAnalysis::Initialise(){
   makeTree = true;
   makeHistos = true;
   if(makeTree){
-		for(int i = 0; i < nWPoints; i++){
-	    fTree[i]   = CreateTree(sWPoints[i],"Created with PAF");
-    	SetLeptonVariables(fTree[i]);
-    	SetJetVariables(fTree[i]);
-    	SetEventVariables(fTree[i]);
-		}
+    for(int i = 0; i < nWPoints; i++){
+      fTree[i]   = CreateTree(sWPoints[i],"Created with PAF");
+      SetLeptonVariables(fTree[i]);
+      SetJetVariables(fTree[i]);
+      SetEventVariables(fTree[i]);
+    }
   }
   InitHistos();
 }
@@ -99,118 +99,118 @@ void WZAnalysis::InsideLoop(){
   passMETfilters = GetParam<Bool_t>("METfilters");
   passTrigger    = GetParam<Bool_t>("passTrigger");
 
-	for (int wP = 0; wP < nWPoints; wP++){
-  	// Leptons and Jets
+  for (int wP = 0; wP < nWPoints; wP++){
+    // Leptons and Jets
 
-			tightLeptons = {};
-			fakeableLeptons = {};
+      tightLeptons = {};
+      fakeableLeptons = {};
 
-			GetLeptonsByWP(wP);
+      GetLeptonsByWP(wP);
  
-  		GetLeptonVariables(tightLeptons, fakeableLeptons, looseLeptons);
-  		GetJetVariables(selJets, Jets15);
-  		GetGenJetVariables(genJets, mcJets);
-  		GetMET();
-  		fhDummy->Fill(1);
-	
-	
-  	if(TNTightLeps == 3 && passTrigger && passMETfilters){ // trilepton event with OSSF + l, passes trigger and MET filters
-    	// Deal with weights:
-    	Float_t lepSF   = selLeptons.at(0).GetSF(0)*selLeptons.at(1).GetSF(0)*selLeptons.at(2).GetSF(0);
-    	Float_t ElecSF = 1; Float_t MuonSF = 1;
-    	Float_t ElecSFUp = 1; Float_t ElecSFDo = 1; Float_t MuonSFUp = 1; Float_t MuonSFDo = 1;
-    	Float_t stat = 0; 
-    	//For muons
-    	//https://twiki.cern.ch/twiki/bin/viewauth/CMS/MuonReferenceEffsRun2
-    	//Additional 1% for ID + 0.5% for Isolation + 0.5% single muon triggers
-	
-    	if(TChannel == iElElEl){
-    	  ElecSF   = selLeptons.at(0).GetSF( 0)*selLeptons.at(1).GetSF( 0)*selLeptons.at(2).GetSF( 0);
-    	  ElecSFUp = selLeptons.at(0).GetSF( 1)*selLeptons.at(1).GetSF( 1)*selLeptons.at(2).GetSF( 1);
-    	  ElecSFDo = selLeptons.at(0).GetSF(-1)*selLeptons.at(1).GetSF(-1)*selLeptons.at(2).GetSF(-1);
-    	  MuonSFUp = 1; MuonSFDo = 1; MuonSF = 1;
-    	}
-    	else if(TChannel == iMuMuMu){
-    	  MuonSF   = selLeptons.at(0).GetSF( 0)*selLeptons.at(1).GetSF( 0)*selLeptons.at(2).GetSF( 0);
-    	  MuonSFUp = selLeptons.at(0).GetSF( 1)*selLeptons.at(1).GetSF( 1)*selLeptons.at(2).GetSF( 1);
-    	  MuonSFDo = selLeptons.at(0).GetSF(-1)*selLeptons.at(1).GetSF(-1)*selLeptons.at(2).GetSF(-1);
-    	  ElecSFUp = 1; ElecSFDo = 1; ElecSF = 1;
-    	}
-			else{
-    	  MuonSFUp = 1; MuonSFDo = 1; MuonSF = 1;ElecSFUp = 1; ElecSFDo = 1; ElecSF = 1;
-				for (int i = 0; i <3; i ++){
-					if (selLeptons.at(i).isMuon){
-						MuonSF   *= selLeptons.at(i).GetSF( 0);
-						MuonSFUp *= selLeptons.at(i).GetSF( 1);
-						MuonSFDo *= selLeptons.at(i).GetSF(-1);				
-					}
-					else{
-						ElecSF   *= selLeptons.at(i).GetSF( 0);
-						ElecSFUp *= selLeptons.at(i).GetSF( 1);
-						ElecSFDo *= selLeptons.at(i).GetSF(-1);				
-					}
-				}
-			}
-	
-    	TWeight             = NormWeight*ElecSF*MuonSF*TrigSF*PUSF;
-    	TWeight_ElecEffUp   = NormWeight*ElecSFUp*MuonSF*TrigSF*PUSF;
-    	TWeight_ElecEffDown = NormWeight*ElecSFDo*MuonSF*TrigSF*PUSF;
-    	TWeight_MuonEffUp   = NormWeight*ElecSF*MuonSFUp*TrigSF*PUSF;
-    	TWeight_MuonEffDown = NormWeight*ElecSF*MuonSFDo*TrigSF*PUSF;
-    	TWeight_TrigUp     = NormWeight*lepSF*(TrigSF+TrigSFerr)*PUSF;
-    	TWeight_TrigDown   = NormWeight*lepSF*(TrigSF-TrigSFerr)*PUSF;
-    	TWeight_PUDown     = NormWeight*lepSF*TrigSF*PUSF_Up;
-    	TWeight_PUUp       = NormWeight*lepSF*TrigSF*PUSF_Down;
-			TIsSR   = false;
-			TIsCRDY = false;
-			TIsCRTT = false;	
-			TIsNewCRDY = false;
-			TIsNewCRTT = false;	
-    	if(gIsData) TWeight = 1;
-    	// Event Selection
-    	// ===================================================================================================================
+      GetLeptonVariables(tightLeptons, fakeableLeptons, looseLeptons);
+      GetJetVariables(selJets, Jets15);
+      GetGenJetVariables(genJets, mcJets);
+      GetMET();
+      fhDummy->Fill(1);
+  
+  
+    if(TNTightLeps == 3 && passTrigger && passMETfilters){ // trilepton event with OSSF + l, passes trigger and MET filters
+      // Deal with weights:
+      Float_t lepSF   = selLeptons.at(0).GetSF(0)*selLeptons.at(1).GetSF(0)*selLeptons.at(2).GetSF(0);
+      Float_t ElecSF = 1; Float_t MuonSF = 1;
+      Float_t ElecSFUp = 1; Float_t ElecSFDo = 1; Float_t MuonSFUp = 1; Float_t MuonSFDo = 1;
+      Float_t stat = 0; 
+      //For muons
+      //https://twiki.cern.ch/twiki/bin/viewauth/CMS/MuonReferenceEffsRun2
+      //Additional 1% for ID + 0.5% for Isolation + 0.5% single muon triggers
+  
+      if(TChannel == iElElEl){
+        ElecSF   = selLeptons.at(0).GetSF( 0)*selLeptons.at(1).GetSF( 0)*selLeptons.at(2).GetSF( 0);
+        ElecSFUp = selLeptons.at(0).GetSF( 1)*selLeptons.at(1).GetSF( 1)*selLeptons.at(2).GetSF( 1);
+        ElecSFDo = selLeptons.at(0).GetSF(-1)*selLeptons.at(1).GetSF(-1)*selLeptons.at(2).GetSF(-1);
+        MuonSFUp = 1; MuonSFDo = 1; MuonSF = 1;
+      }
+      else if(TChannel == iMuMuMu){
+        MuonSF   = selLeptons.at(0).GetSF( 0)*selLeptons.at(1).GetSF( 0)*selLeptons.at(2).GetSF( 0);
+        MuonSFUp = selLeptons.at(0).GetSF( 1)*selLeptons.at(1).GetSF( 1)*selLeptons.at(2).GetSF( 1);
+        MuonSFDo = selLeptons.at(0).GetSF(-1)*selLeptons.at(1).GetSF(-1)*selLeptons.at(2).GetSF(-1);
+        ElecSFUp = 1; ElecSFDo = 1; ElecSF = 1;
+      }
+      else{
+        MuonSFUp = 1; MuonSFDo = 1; MuonSF = 1;ElecSFUp = 1; ElecSFDo = 1; ElecSF = 1;
+        for (int i = 0; i <3; i ++){
+          if (selLeptons.at(i).isMuon){
+            MuonSF   *= selLeptons.at(i).GetSF( 0);
+            MuonSFUp *= selLeptons.at(i).GetSF( 1);
+            MuonSFDo *= selLeptons.at(i).GetSF(-1);        
+          }
+          else{
+            ElecSF   *= selLeptons.at(i).GetSF( 0);
+            ElecSFUp *= selLeptons.at(i).GetSF( 1);
+            ElecSFDo *= selLeptons.at(i).GetSF(-1);        
+          }
+        }
+      }
+  
+      TWeight             = NormWeight*ElecSF*MuonSF*TrigSF*PUSF;
+      TWeight_ElecEffUp   = NormWeight*ElecSFUp*MuonSF*TrigSF*PUSF;
+      TWeight_ElecEffDown = NormWeight*ElecSFDo*MuonSF*TrigSF*PUSF;
+      TWeight_MuonEffUp   = NormWeight*ElecSF*MuonSFUp*TrigSF*PUSF;
+      TWeight_MuonEffDown = NormWeight*ElecSF*MuonSFDo*TrigSF*PUSF;
+      TWeight_TrigUp     = NormWeight*lepSF*(TrigSF+TrigSFerr)*PUSF;
+      TWeight_TrigDown   = NormWeight*lepSF*(TrigSF-TrigSFerr)*PUSF;
+      TWeight_PUDown     = NormWeight*lepSF*TrigSF*PUSF_Up;
+      TWeight_PUUp       = NormWeight*lepSF*TrigSF*PUSF_Down;
+      TIsSR   = false;
+      TIsCRDY = false;
+      TIsCRTT = false;  
+      TIsNewCRDY = false;
+      TIsNewCRTT = false;  
+      if(gIsData) TWeight = 1;
+      // Event Selection
+      // ===================================================================================================================
 
-    	if(TNTightLeps == 3 && TNOSSF > 0){ 
-				AssignWZLeptons();
-				if (lepZ1.Pt() > 25 && lepZ2.Pt() > 10 && lepW.Pt() > 25){//3 lepton, has OSSF, leptons assigned to W and Z
-	  	    // fHyields[gChannel][0] -> Fill(itrilepton, TWeight);
-	  	    // FillHistos(gChannel, itrilepton);
-	  	    // FillDYHistos(gChannel);
-    	  
-    	  	if(TMath::Abs(TMll - nomZmass)< 15. && TMinMll > 4. && (lepZ1.p + lepZ2.p + lepW.p).M() > 100.  ){ //  Z window + exlcude low masses + M_3l selection 
-						// fHyields[gChannel][0] -> Fill(ionZ, TWeight);
-    	  	  // FillHistos(gChannel, ionZ);
-						// The last two cuts define the Control/Signal regions
-						
-						// Signal Region
-    	  	  if(TMET > 30.){   // MET > 30 always
-    	  	  	// fHyields[gChannel][0] -> Fill(imet, TWeight);
-    	  	    // FillHistos(gChannel, imet);
-    	  	    if(TNBtags == 0){ //Exactly 0 btags
-    	  	      //fHyields[gChannel][0] -> Fill(i0btag, TWeight);
-    	  	      //FillHistos(gChannel, i0btag);
-								TIsSR   = true;
-    	        }
-    	  	    else if(TNBtags > 0 && (TNOSSF == 0 || (TNOSSF > 0 && TMath::Abs(TM3l - nomZmass) > 5))){ //1 or more btags
-								TIsCRTT = true ;
-    	        }
-    	      }
-						else if (TMET < 30. && TNBtags == 0){
-							TIsCRDY = true ;
-						}
+      if(TNTightLeps == 3 && TNOSSF > 0){ 
+        AssignWZLeptons();
+        if (lepZ1.Pt() > 25 && lepZ2.Pt() > 10 && lepW.Pt() > 25){//3 lepton, has OSSF, leptons assigned to W and Z
+          // fHyields[gChannel][0] -> Fill(itrilepton, TWeight);
+          // FillHistos(gChannel, itrilepton);
+          // FillDYHistos(gChannel);
+        
+          if(TMath::Abs(TMll - nomZmass)< 15. && TMinMll > 4. && (lepZ1.p + lepZ2.p + lepW.p).M() > 100.  ){ //  Z window + exlcude low masses + M_3l selection 
+            // fHyields[gChannel][0] -> Fill(ionZ, TWeight);
+            // FillHistos(gChannel, ionZ);
+            // The last two cuts define the Control/Signal regions
+            
+            // Signal Region
+            if(TMET > 30.){   // MET > 30 always
+              // fHyields[gChannel][0] -> Fill(imet, TWeight);
+              // FillHistos(gChannel, imet);
+              if(TNBtags == 0){ //Exactly 0 btags
+                //fHyields[gChannel][0] -> Fill(i0btag, TWeight);
+                //FillHistos(gChannel, i0btag);
+                TIsSR   = true;
+              }
+              else if(TNBtags > 0 && (TNOSSF == 0 || (TNOSSF > 0 && TMath::Abs(TM3l - nomZmass) > 5))){ //1 or more btags
+                TIsCRTT = true ;
+              }
+            }
+            else if (TMET < 30. && TNBtags == 0){
+              TIsCRDY = true ;
+            }
 
-    	    }
-					if (TMath::Abs(TMll - nomZmass)< 15. && TMinMll > 4. && TMET < 30.){
-						TIsNewCRDY = true;
-					}
-					if (TMath::Abs(TMll - nomZmass)> 15. && TMath::Abs(TM3l - nomZmass) > 5 &&  TMinMll > 4. && (lepZ1.p + lepZ2.p + lepW.p).M() > 100. && TMET > 30.){
-						TIsNewCRTT = true;
-					}  
-					if (TIsSR || TIsCRDY || TIsCRTT || TIsNewCRDY || TIsNewCRTT) fTree[wP] -> Fill();
-    	  }
-    	}   
-  	}
-	}
+          }
+          if (TMath::Abs(TMll - nomZmass)< 15. && TMinMll > 4. && TMET < 30.){
+            TIsNewCRDY = true;
+          }
+          if (TMath::Abs(TMll - nomZmass)> 15. && TMath::Abs(TM3l - nomZmass) > 5 &&  TMinMll > 4. && (lepZ1.p + lepZ2.p + lepW.p).M() > 100. && TMET > 30.){
+            TIsNewCRTT = true;
+          }  
+          if (TIsSR || TIsCRDY || TIsCRTT || TIsNewCRDY || TIsNewCRTT) fTree[wP] -> Fill();
+        }
+      }   
+    }
+  }
 }
 
 
@@ -364,30 +364,30 @@ void WZAnalysis::SetEventVariables(TTree* iniTree){
 //------------------------------------------------------------------
 
 void WZAnalysis::GetLeptonsByWP(Int_t wPValue){
-	Int_t nFakeableLeptons = foLeptons.size();
-	Int_t nTightLeptons = selLeptons.size();
+  Int_t nFakeableLeptons = foLeptons.size();
+  Int_t nTightLeptons = selLeptons.size();
 
-	if (wPValue == top){
-		for (int k = 0; k < nTightLeptons; k++){ // No FO for top ID
-			if (selLeptons.at(k).idMVA >= 10){
-				tightLeptons.push_back(selLeptons.at(k));
-				fakeableLeptons.push_back(selLeptons.at(k));
-			}
-		}
-	}
-	else {
-		for (int k = 0; k < nFakeableLeptons; k++){
-			if (foLeptons.at(k).idMVA%10 > wPValue){
-				fakeableLeptons.push_back(foLeptons.at(k));
-			}
-		}
-	
-		for (int k = 0; k < nTightLeptons; k++){
-			if (selLeptons.at(k).idMVA%10 > wPValue){
-				tightLeptons.push_back(selLeptons.at(k));
-			}
-		}
-	}
+  if (wPValue == top){
+    for (int k = 0; k < nTightLeptons; k++){ // No FO for top ID
+      if (selLeptons.at(k).idMVA >= 10){
+        tightLeptons.push_back(selLeptons.at(k));
+        fakeableLeptons.push_back(selLeptons.at(k));
+      }
+    }
+  }
+  else {
+    for (int k = 0; k < nFakeableLeptons; k++){
+      if (foLeptons.at(k).idMVA%10 > wPValue){
+        fakeableLeptons.push_back(foLeptons.at(k));
+      }
+    }
+  
+    for (int k = 0; k < nTightLeptons; k++){
+      if (selLeptons.at(k).idMVA%10 > wPValue){
+        tightLeptons.push_back(selLeptons.at(k));
+      }
+    }
+  }
 }
 
 void WZAnalysis::GetLeptonVariables(std::vector<Lepton> selLeptons, std::vector<Lepton> foLeptons, std::vector<Lepton> looseLeptons){
@@ -401,11 +401,11 @@ void WZAnalysis::GetLeptonVariables(std::vector<Lepton> selLeptons, std::vector<
     TLep_E[i]      = selLeptons.at(i).E();    
     TLep_Charge[i] = selLeptons.at(i).charge;    
   }
-	//Require exactly 3 leptons 
+  //Require exactly 3 leptons 
   if(TNTightLeps != 3 ) gChannel = -1;
-	//Charge compatibility with WZ production
-	else if(TMath::Abs(selLeptons.at(0).charge + selLeptons.at(1).charge + selLeptons.at(2).charge) != 1) gChannel = -1;
-	//Combinatory of posible final leptons
+  //Charge compatibility with WZ production
+  else if(TMath::Abs(selLeptons.at(0).charge + selLeptons.at(1).charge + selLeptons.at(2).charge) != 1) gChannel = -1;
+  //Combinatory of posible final leptons
   else if(selLeptons.at(0).isMuon && selLeptons.at(1).isMuon && selLeptons.at(2).isMuon) gChannel = iMuMuMu;
   else if(selLeptons.at(0).isMuon && selLeptons.at(1).isMuon && selLeptons.at(2).isElec) gChannel = iElMuMu;
   else if(selLeptons.at(0).isMuon && selLeptons.at(1).isElec && selLeptons.at(2).isMuon) gChannel = iElMuMu;
@@ -414,16 +414,16 @@ void WZAnalysis::GetLeptonVariables(std::vector<Lepton> selLeptons, std::vector<
   else if(selLeptons.at(0).isElec && selLeptons.at(1).isMuon && selLeptons.at(2).isElec) gChannel = iElElMu;
   else if(selLeptons.at(0).isElec && selLeptons.at(1).isElec && selLeptons.at(2).isMuon) gChannel = iElElMu;
   else if(selLeptons.at(0).isElec && selLeptons.at(1).isElec && selLeptons.at(2).isElec) gChannel = iElElEl;
-	TMinMll = 100000;
-	TNOSSF = 0;
-	for(Int_t i = 0; i < TNTightLeps; i++){
-		for(Int_t j = i+1; j < TNTightLeps; j++){
-			if (selLeptons.at(j).isMuon && selLeptons.at(i).isMuon && selLeptons.at(i).charge*selLeptons.at(j).charge == -1) 					TNOSSF++;
-			if (selLeptons.at(j).isElec && selLeptons.at(i).isElec && selLeptons.at(i).charge*selLeptons.at(j).charge == -1) 					TNOSSF++;
-			Float_t hypMll = (selLeptons.at(j).p + selLeptons.at(i).p).M();
-			if (hypMll < TMinMll) TMinMll = hypMll;
-		}
-	}
+  TMinMll = 100000;
+  TNOSSF = 0;
+  for(Int_t i = 0; i < TNTightLeps; i++){
+    for(Int_t j = i+1; j < TNTightLeps; j++){
+      if (selLeptons.at(j).isMuon && selLeptons.at(i).isMuon && selLeptons.at(i).charge*selLeptons.at(j).charge == -1)           TNOSSF++;
+      if (selLeptons.at(j).isElec && selLeptons.at(i).isElec && selLeptons.at(i).charge*selLeptons.at(j).charge == -1)           TNOSSF++;
+      Float_t hypMll = (selLeptons.at(j).p + selLeptons.at(i).p).M();
+      if (hypMll < TMinMll) TMinMll = hypMll;
+    }
+  }
 
   TChannel = gChannel;
   gChannel = gChannel -1; // gchannel used for chan index of histograms
@@ -566,40 +566,40 @@ void WZAnalysis::FillHistos(Int_t ch, Int_t cut){
 
 void WZAnalysis::AssignWZLeptons()
 {
-	Float_t dZmass = 100000.; 
-	Int_t indexZ1;
-	Int_t indexZ2;
-	for(Int_t i = 0; i < TNTightLeps; i++){
-		for(Int_t j = i+1; j < TNTightLeps; j++){
-			if ( ( (selLeptons.at(j).isMuon && selLeptons.at(i).isMuon) || (selLeptons.at(j).isElec && selLeptons.at(i).isElec)    ) && selLeptons.at(i).charge*selLeptons.at(j).charge == -1){
-				Float_t hypZmass = (selLeptons.at(j).p + selLeptons.at(i).p).M();
-				if (TMath::Abs(hypZmass-nomZmass) < dZmass){
-					dZmass = TMath::Abs(hypZmass-nomZmass);
-					TMll  = hypZmass;
-					indexZ1 = j;
-					indexZ2 = i;
-					if (selLeptons.at(j).Pt() > selLeptons.at(i).Pt()) {
-						lepZ1 = selLeptons.at(j);
-						lepZ2 = selLeptons.at(i); 
-					}
-					else{
-						lepZ1 = selLeptons.at(i);
-						lepZ2 = selLeptons.at(j);
-					}
-				}
-			}
-		}
-	}
-	for(Int_t i = 0; i < TNTightLeps; i++){
-		if (i != indexZ1 && i != indexZ2){
-			lepW = selLeptons.at(i);
-		}
-	}	
-	TLorentzVector metVector = TLorentzVector();
-	metVector.SetPtEtaPhiM(TMET, TMET_Phi, 0., 0.);
-	TM3l = (lepZ1.p + lepZ2.p + lepW.p).M();
-	TMtWZ = (lepZ1.p + lepZ2.p + lepW.p + metVector).Mt();
-	TMtW  = (lepW.p + metVector).Mt();
+  Float_t dZmass = 100000.; 
+  Int_t indexZ1;
+  Int_t indexZ2;
+  for(Int_t i = 0; i < TNTightLeps; i++){
+    for(Int_t j = i+1; j < TNTightLeps; j++){
+      if ( ( (selLeptons.at(j).isMuon && selLeptons.at(i).isMuon) || (selLeptons.at(j).isElec && selLeptons.at(i).isElec)    ) && selLeptons.at(i).charge*selLeptons.at(j).charge == -1){
+        Float_t hypZmass = (selLeptons.at(j).p + selLeptons.at(i).p).M();
+        if (TMath::Abs(hypZmass-nomZmass) < dZmass){
+          dZmass = TMath::Abs(hypZmass-nomZmass);
+          TMll  = hypZmass;
+          indexZ1 = j;
+          indexZ2 = i;
+          if (selLeptons.at(j).Pt() > selLeptons.at(i).Pt()) {
+            lepZ1 = selLeptons.at(j);
+            lepZ2 = selLeptons.at(i); 
+          }
+          else{
+            lepZ1 = selLeptons.at(i);
+            lepZ2 = selLeptons.at(j);
+          }
+        }
+      }
+    }
+  }
+  for(Int_t i = 0; i < TNTightLeps; i++){
+    if (i != indexZ1 && i != indexZ2){
+      lepW = selLeptons.at(i);
+    }
+  }  
+  TLorentzVector metVector = TLorentzVector();
+  metVector.SetPtEtaPhiM(TMET, TMET_Phi, 0., 0.);
+  TM3l = (lepZ1.p + lepZ2.p + lepW.p).M();
+  TMtWZ = (lepZ1.p + lepZ2.p + lepW.p + metVector).Mt();
+  TMtW  = (lepW.p + metVector).Mt();
 }
 
 

--- a/packages/WZAnalysis/WZAnalysis.C
+++ b/packages/WZAnalysis/WZAnalysis.C
@@ -173,22 +173,22 @@ void WZAnalysis::InsideLoop(){
     	if(TNTightLeps == 3 && TNOSSF > 0){ 
 				AssignWZLeptons();
 				if (lepZ1.Pt() > 25 && lepZ2.Pt() > 10 && lepW.Pt() > 25){//3 lepton, has OSSF, leptons assigned to W and Z
-	  	    fHyields[gChannel][0] -> Fill(itrilepton, TWeight);
-	  	    FillHistos(gChannel, itrilepton);
-	  	    FillDYHistos(gChannel);
+	  	    // fHyields[gChannel][0] -> Fill(itrilepton, TWeight);
+	  	    // FillHistos(gChannel, itrilepton);
+	  	    // FillDYHistos(gChannel);
     	  
     	  	if(TMath::Abs(TMll - nomZmass)< 15. && TMinMll > 4. && (lepZ1.p + lepZ2.p + lepW.p).M() > 100.  ){ //  Z window + exlcude low masses + M_3l selection 
-						fHyields[gChannel][0] -> Fill(ionZ, TWeight);
-    	  	  FillHistos(gChannel, ionZ);
+						// fHyields[gChannel][0] -> Fill(ionZ, TWeight);
+    	  	  // FillHistos(gChannel, ionZ);
 						// The last two cuts define the Control/Signal regions
 						
 						// Signal Region
     	  	  if(TMET > 30.){   // MET > 30 always
-    	  	  	fHyields[gChannel][0] -> Fill(imet, TWeight);
-    	  	    FillHistos(gChannel, imet);
+    	  	  	// fHyields[gChannel][0] -> Fill(imet, TWeight);
+    	  	    // FillHistos(gChannel, imet);
     	  	    if(TNBtags == 0){ //Exactly 0 btags
-    	  	      fHyields[gChannel][0] -> Fill(i0btag, TWeight);
-    	  	      FillHistos(gChannel, i0btag);
+    	  	      //fHyields[gChannel][0] -> Fill(i0btag, TWeight);
+    	  	      //FillHistos(gChannel, i0btag);
 								TIsSR   = true;
     	        }
     	  	    else if(TNBtags > 0 && (TNOSSF == 0 || (TNOSSF > 0 && TMath::Abs(TM3l - nomZmass) > 5))){ //1 or more btags
@@ -200,10 +200,10 @@ void WZAnalysis::InsideLoop(){
 						}
 
     	    }
-					else if (TMath::Abs(TMll - nomZmass)< 15. && TMinMll > 4. && TMET < 30.){
+					if (TMath::Abs(TMll - nomZmass)< 15. && TMinMll > 4. && TMET < 30.){
 						TIsNewCRDY = true;
 					}
-					else if (TMath::Abs(TMll - nomZmass)> 15. && TMath::Abs(TM3l - nomZmass) > 5 &&  TMinMll > 4. && (lepZ1.p + lepZ2.p + lepW.p).M() > 100. && TMET > 30.){
+					if (TMath::Abs(TMll - nomZmass)> 15. && TMath::Abs(TM3l - nomZmass) > 5 &&  TMinMll > 4. && (lepZ1.p + lepZ2.p + lepW.p).M() > 100. && TMET > 30.){
 						TIsNewCRTT = true;
 					}  
 					if (TIsSR || TIsCRDY || TIsCRTT || TIsNewCRDY || TIsNewCRTT) fTree[wP] -> Fill();

--- a/packages/WZAnalysis/WZAnalysis.h
+++ b/packages/WZAnalysis/WZAnalysis.h
@@ -19,7 +19,6 @@ const TString sWPoints[nWPoints] = {"nolepMVA","veryLoose", "loose", "medium", "
 const TString gSys[nSysts] = {"0"};
 
 
-
 class WZAnalysis : public PAFChainItemSelector{
   public:
     WZAnalysis();
@@ -30,20 +29,20 @@ class WZAnalysis : public PAFChainItemSelector{
     std::vector<Lepton> genLeptons  ;
     std::vector<Lepton> selLeptons  ; // Main container
     std::vector<Lepton> foLeptons   ; // Main container
-		std::vector<Lepton> looseLeptons;
+    std::vector<Lepton> looseLeptons;
 
 
-		std::vector<Lepton> tightLeptons;
-		std::vector<Lepton> fakeableLeptons;
+    std::vector<Lepton> tightLeptons;
+    std::vector<Lepton> fakeableLeptons;
 
 
     std::vector<Jet> selJets ;
     std::vector<Jet> selJetsJecUp   ;
     std::vector<Jet> selJetsJecDown ;
-		Lepton lepZ1;
-		Lepton lepZ2;
-		Lepton lepW;
-		Float_t nomZmass = 91.1876;
+    Lepton lepZ1;
+    Lepton lepZ2;
+    Lepton lepW;
+    Float_t nomZmass = 91.1876;
 
 
     std::vector<Jet> Jets15  ;
@@ -63,7 +62,7 @@ class WZAnalysis : public PAFChainItemSelector{
     void GetLeptonVariables(std::vector<Lepton> selLeptons, std::vector<Lepton> foLeptons, std::vector<Lepton> looseLeptons);
     void GetJetVariables(std::vector<Jet> selJets, std::vector<Jet> cleanedJets15, Float_t ptCut = 30);
     void GetGenJetVariables(std::vector<Jet> genJets, std::vector<Jet> mcJets);
-		void GetLeptonsByWP(Int_t wPValue); 
+    void GetLeptonsByWP(Int_t wPValue); 
     void GetMET();
     Int_t nFiduJets; Int_t nFidubJets; 
 
@@ -97,39 +96,39 @@ class WZAnalysis : public PAFChainItemSelector{
 
 
     void makeLeptonCollections();
-		void AssignWZLeptons();
+    void AssignWZLeptons();
 
     //Variables
     Float_t TWeight;   // Total nominal weight
     Float_t TMll;      // Invariant mass of OSSF (best Z mass)
-		Float_t TMtW;			 // M_T of the W boson
-		Float_t TMtWZ;			 // M_T of the WZ system
-		Float_t TM3l;      // Invariant mass of the three leptons
-		Float_t TMinMll;   // Invariant mass of any pair
-    Int_t   TNOSSF; 		 // Number of OSSF pairs
+    Float_t TMtW;       // M_T of the W boson
+    Float_t TMtWZ;       // M_T of the WZ system
+    Float_t TM3l;      // Invariant mass of the three leptons
+    Float_t TMinMll;   // Invariant mass of any pair
+    Int_t   TNOSSF;      // Number of OSSF pairs
     Float_t TMET;      // Reco MET
     Float_t TGenMET;   // Gent MET
     Float_t TMET_Phi;  // MET phi
 
-		// Event classification
-		Bool_t  TIsSR;
-		Bool_t  TIsCRTT;
-		Bool_t  TIsCRDY;
-		Bool_t  TIsNewCRTT;
-		Bool_t  TIsNewCRDY;
+    // Event classification
+    Bool_t  TIsSR;
+    Bool_t  TIsCRTT;
+    Bool_t  TIsCRDY;
+    Bool_t  TIsNewCRTT;
+    Bool_t  TIsNewCRDY;
 
     Int_t   TNFOLeps;
     Int_t   TNTightLeps;
     Int_t   TChannel;
 
-		// Lepton Things
+    // Lepton Things
     Float_t TLep_Pt[10];    
     Float_t TLep_Eta[10];
     Float_t TLep_Phi[10];
     Float_t TLep_E[10];
     Float_t TLep_Charge[10];
 
-		// Jet Things
+    // Jet Things
     Int_t TNJets;            
     Int_t TNBtags;
     Float_t TJet_Pt[20];
@@ -237,7 +236,6 @@ class WZAnalysis : public PAFChainItemSelector{
   TH1F* fhDummy;
   TH1F*  fHyields[nChannels][nSysts];
   TH1F*  fHFiduYields[nChannels][nSysts];
-
 
   protected:
 

--- a/packages/WZAnalysis/WZAnalysis.h
+++ b/packages/WZAnalysis/WZAnalysis.h
@@ -96,7 +96,6 @@ class WZAnalysis : public PAFChainItemSelector{
 
 
     void makeLeptonCollections();
-    void AssignWZLeptons();
 
     //Variables
     Float_t TWeight;   // Total nominal weight

--- a/packages/WZAnalysis/WZAnalysis.h
+++ b/packages/WZAnalysis/WZAnalysis.h
@@ -87,8 +87,8 @@ class WZAnalysis : public PAFChainItemSelector{
     Double_t getSysM(const TString& sys = "Norm");
     Double_t getM(vector<TLorentzVector>);
 
-    void lepMVA(Lepton& lep, TString wp);
-    void pogID (Lepton& lep, TString wp);
+    bool lepMVA(Lepton& lep, TString wp);
+    bool pogID (Lepton& lep, TString wp);
 
     void makeLeptonCollections();
 

--- a/packages/WZAnalysis/WZAnalysis.h
+++ b/packages/WZAnalysis/WZAnalysis.h
@@ -5,14 +5,15 @@
 #include <iostream>
 #include <vector>
 
-//enum eChannels{iUnkChan, iElMu, iMuon, iElec, nChannels};
-const Int_t nChannels = 3;
-enum eLevels  {idilepton, iZVeto, iMETcut, i2jets, i1btag, nLevels};
+enum eChannels{iElElEl, iElElMu, iElMuMu,iMuMuMu};
+const Int_t nChannels = 4;
+enum eLevels  {itrilepton, ionZ, imet, i0btag, im3l, nLevels};
 enum eSysts   {inorm, nSysts};
 const int nWeights = 248;
-const TString gChanLabel[nChannels] = {"ElMu", "Muon","Elec"};
-const TString sCut[nLevels] = {"dilepton", "ZVeto", "MET", "2jets", "1btag"};
+const TString gChanLabel[nChannels] = {"ElElEl", "ElElMu","ElMuMu","MuMuMu"};
+const TString sCut[nLevels] = {"trilepton","onZ","met","0btag","m3l"};
 const TString gSys[nSysts] = {"0"};
+
 
 
 class WZAnalysis : public PAFChainItemSelector{
@@ -34,8 +35,10 @@ class WZAnalysis : public PAFChainItemSelector{
     std::vector<Jet> selJets ;
     std::vector<Jet> selJetsJecUp   ;
     std::vector<Jet> selJetsJecDown ;
-
-
+		Lepton lepZ1;
+		Lepton lepZ2;
+		Lepton lepW;
+		Float_t nomZmass = 91.1876;
 
 
     std::vector<Jet> Jets15  ;
@@ -66,7 +69,6 @@ class WZAnalysis : public PAFChainItemSelector{
     Int_t   gChannel;
     Bool_t  passMETfilters;
     Bool_t  passTrigger;
-    Bool_t  isSS;
     Float_t NormWeight;
 
     void InitHistos();
@@ -91,18 +93,22 @@ class WZAnalysis : public PAFChainItemSelector{
     bool pogID (Lepton& lep, TString wp);
 
     void makeLeptonCollections();
+		void AssignWZLeptons();
 
     //Variables
     Float_t TWeight;   // Total nominal weight
-    Float_t TMll;      // Invariant mass
+    Float_t TMll;      // Invariant mass of OSSF (best Z mass)
+		Float_t TMinMll;    // Invariant mass of any pair
+    Int_t TNOSSF; 		 // Number of OSSF pairs
     Float_t TMET;      // MET
     Float_t TGenMET;     
     Float_t TMET_Phi;  // MET phi
 
+
     Int_t   TNVetoLeps;
     Int_t   TNSelLeps;
     Int_t   TChannel;
-    Bool_t   TIsSS;
+
     Float_t TLep_Pt[10];    
     Float_t TLep_Eta[10];
     Float_t TLep_Phi[10];
@@ -170,8 +176,7 @@ class WZAnalysis : public PAFChainItemSelector{
     Float_t  C_jll          , C_jllJESUp          , C_jllJESDown          ;
     Float_t  DilepJetPt     , DilepJetPtJESUp     , DilepJetPtJESDown     ;
     Float_t  TBDT           , TBDTJESUp           , TBDTJESDown           ;
-    /* Float_t  TBDTBTagUp     , TBDTBTagDown; */
-    /* Float_t  TBDTMistagUp   , TBDTBMistagDown; */
+
 
     Float_t  nBTotal          , nBTotalJESUp          , nBTotalJESDown          ; 
     Float_t  DilepmetjetOverHT, DilepmetjetOverHTJESUp, DilepmetjetOverHTJESDown; 
@@ -217,7 +222,7 @@ class WZAnalysis : public PAFChainItemSelector{
   TH1F* fhDummy;
   TH1F*  fHyields[nChannels][nSysts];
   TH1F*  fHFiduYields[nChannels][nSysts];
-  TH1F*  fHSSyields[nChannels][nSysts];
+
 
   protected:
 

--- a/packages/WZAnalysis/WZAnalysis.h
+++ b/packages/WZAnalysis/WZAnalysis.h
@@ -9,13 +9,13 @@ enum eChannels{iElElEl, iElElMu, iElMuMu,iMuMuMu};
 const Int_t nChannels = 4;
 enum eLevels  {itrilepton, ionZ, imet, i0btag, im3l, nLevels};
 enum eSysts   {inorm, nSysts};
-enum eWPoints  {veryLoose, loose, medium, tight, veryTight, extraTight};
+enum eWPoints  {nolepMVA, veryLoose, loose, medium, tight, veryTight, extraTight, top};
 
-const int nWPoints = 7;
+const int nWPoints = 8;
 const int nWeights = 248;
 const TString gChanLabel[nChannels] = {"ElElEl", "ElElMu","ElMuMu","MuMuMu"};
 const TString sCut[nLevels] = {"trilepton","onZ","met","0btag","m3l"};
-const TString sWPoints[nWPoints] = {"nolepMVA","veryLoose", "loose", "medium", "tight", "veryTight", "extraTight"};
+const TString sWPoints[nWPoints] = {"nolepMVA","veryLoose", "loose", "medium", "tight", "veryTight", "extraTight", "top"};
 const TString gSys[nSysts] = {"0"};
 
 
@@ -102,24 +102,35 @@ class WZAnalysis : public PAFChainItemSelector{
     //Variables
     Float_t TWeight;   // Total nominal weight
     Float_t TMll;      // Invariant mass of OSSF (best Z mass)
-		Float_t TMinMll;    // Invariant mass of any pair
-    Int_t TNOSSF; 		 // Number of OSSF pairs
-    Float_t TMET;      // MET
-    Float_t TGenMET;     
+		Float_t TMtW;			 // M_T of the W boson
+		Float_t TMtWZ;			 // M_T of the WZ system
+		Float_t TM3l;      // Invariant mass of the three leptons
+		Float_t TMinMll;   // Invariant mass of any pair
+    Int_t   TNOSSF; 		 // Number of OSSF pairs
+    Float_t TMET;      // Reco MET
+    Float_t TGenMET;   // Gent MET
     Float_t TMET_Phi;  // MET phi
 
+		// Event classification
+		Bool_t  TIsSR;
+		Bool_t  TIsCRTT;
+		Bool_t  TIsCRDY;
+		Bool_t  TIsNewCRTT;
+		Bool_t  TIsNewCRDY;
 
     Int_t   TNFOLeps;
     Int_t   TNTightLeps;
     Int_t   TChannel;
 
+		// Lepton Things
     Float_t TLep_Pt[10];    
     Float_t TLep_Eta[10];
     Float_t TLep_Phi[10];
     Float_t TLep_E[10];
     Float_t TLep_Charge[10];
 
-    Int_t TNJets;            // Jets...
+		// Jet Things
+    Int_t TNJets;            
     Int_t TNBtags;
     Float_t TJet_Pt[20];
     Float_t TJet_Eta[20];

--- a/packages/WZAnalysis/WZAnalysis.h
+++ b/packages/WZAnalysis/WZAnalysis.h
@@ -9,9 +9,13 @@ enum eChannels{iElElEl, iElElMu, iElMuMu,iMuMuMu};
 const Int_t nChannels = 4;
 enum eLevels  {itrilepton, ionZ, imet, i0btag, im3l, nLevels};
 enum eSysts   {inorm, nSysts};
+enum eWPoints  {veryLoose, loose, medium, tight, veryTight, extraTight};
+
+const int nWPoints = 7;
 const int nWeights = 248;
 const TString gChanLabel[nChannels] = {"ElElEl", "ElElMu","ElMuMu","MuMuMu"};
 const TString sCut[nLevels] = {"trilepton","onZ","met","0btag","m3l"};
+const TString sWPoints[nWPoints] = {"nolepMVA","veryLoose", "loose", "medium", "tight", "veryTight", "extraTight"};
 const TString gSys[nSysts] = {"0"};
 
 
@@ -25,13 +29,14 @@ class WZAnalysis : public PAFChainItemSelector{
     virtual void Summary();
     std::vector<Lepton> genLeptons  ;
     std::vector<Lepton> selLeptons  ; // Main container
-    std::vector<Lepton> vetoLeptons ; // Main container
-    std::vector<Lepton> selLeptonsLV  ; // lepMVA VT
-    std::vector<Lepton> selLeptonsLM  ; // lepMVA M
-    std::vector<Lepton> vetoLeptonsLL; // lepMVA M
-    std::vector<Lepton> selLeptonsPT  ; // POG T
-    std::vector<Lepton> selLeptonsPM  ; // POG M
-    std::vector<Lepton> vetoLeptonsPL ; // POG M
+    std::vector<Lepton> foLeptons   ; // Main container
+		std::vector<Lepton> looseLeptons;
+
+
+		std::vector<Lepton> tightLeptons;
+		std::vector<Lepton> fakeableLeptons;
+
+
     std::vector<Jet> selJets ;
     std::vector<Jet> selJetsJecUp   ;
     std::vector<Jet> selJetsJecDown ;
@@ -46,18 +51,19 @@ class WZAnalysis : public PAFChainItemSelector{
     std::vector<Jet> mcJets  ;
     std::vector<Jet> vetoJets;
 
-    TTree* fTree;
+    TTree* fTree[nWPoints] = {0};
     Float_t TLHEWeight[254];
-    void SetLeptonVariables();
-    void SetJetVariables();
-    void SetEventVariables();
+    void SetLeptonVariables(TTree* iniTree);
+    void SetJetVariables(TTree* iniTree);
+    void SetEventVariables(TTree* iniTree);
 
     Bool_t makeHistos = false;
     Bool_t makeTree   = false;
 
-    void GetLeptonVariables(std::vector<Lepton> selLeptons, std::vector<Lepton> VetoLeptons);
+    void GetLeptonVariables(std::vector<Lepton> selLeptons, std::vector<Lepton> foLeptons, std::vector<Lepton> looseLeptons);
     void GetJetVariables(std::vector<Jet> selJets, std::vector<Jet> cleanedJets15, Float_t ptCut = 30);
     void GetGenJetVariables(std::vector<Jet> genJets, std::vector<Jet> mcJets);
+		void GetLeptonsByWP(Int_t wPValue); 
     void GetMET();
     Int_t nFiduJets; Int_t nFidubJets; 
 
@@ -89,8 +95,6 @@ class WZAnalysis : public PAFChainItemSelector{
     Double_t getSysM(const TString& sys = "Norm");
     Double_t getM(vector<TLorentzVector>);
 
-    bool lepMVA(Lepton& lep, TString wp);
-    bool pogID (Lepton& lep, TString wp);
 
     void makeLeptonCollections();
 		void AssignWZLeptons();
@@ -105,8 +109,8 @@ class WZAnalysis : public PAFChainItemSelector{
     Float_t TMET_Phi;  // MET phi
 
 
-    Int_t   TNVetoLeps;
-    Int_t   TNSelLeps;
+    Int_t   TNFOLeps;
+    Int_t   TNTightLeps;
     Int_t   TChannel;
 
     Float_t TLep_Pt[10];    

--- a/plotter/WZ/Conversions.sh
+++ b/plotter/WZ/Conversions.sh
@@ -1,0 +1,9 @@
+# ====================
+# CONVERSIONS
+# ====================
+root -l -b -q 'RunAnalyserPAF.C("TGJets & TGJets_ext"  , "WZ",16, -4)'
+root -l -b -q 'RunAnalyserPAF.C("TTGJets & TTGJets_ext", "WZ",30   )'
+root -l -b -q 'RunAnalyserPAF.C("WGToLNuG"             , "WZ",16, -4)'
+root -l -b -q 'RunAnalyserPAF.C("ZGTo2LG"              , "WZ",16, -4)'
+root -l -b -q 'RunAnalyserPAF.C("WZG_amcatnlo"   , "WZ",16, -4)' # WZG_TuneCUETP8M1_13TeV-amcatnlo-pythia8
+root -l -b -q 'RunAnalyserPAF.C("WWG_amcatnlo"   , "WZ",16)' # WWG_TuneCUETP8M1_13TeV-amcatnlo-pythia8

--- a/plotter/WZ/Data.sh
+++ b/plotter/WZ/Data.sh
@@ -1,0 +1,6 @@
+# ====================
+# DATA
+# ====================
+root -l -b -q 'RunAnalyserPAF.C("MuonEG"    , "WZ",60)'
+root -l -b -q 'RunAnalyserPAF.C("DoubleMuon", "WZ",60)'
+root -l -b -q 'RunAnalyserPAF.C("DoubleEG"  , "WZ",60)'

--- a/plotter/WZ/DrawPlots.C
+++ b/plotter/WZ/DrawPlots.C
@@ -1,0 +1,135 @@
+R__LOAD_LIBRARY(Histo.C+)
+R__LOAD_LIBRARY(Looper.C+)
+R__LOAD_LIBRARY(TResultsTable.C+)
+R__LOAD_LIBRARY(Plot.C+)
+#include "Histo.h"
+#include "Looper.h"
+#include "Plot.h"
+
+void DrawPlot(TString var, TString cut, TString chan, Int_t nbins, Float_t bin0, Float_t binN, TString Xtitle, TString varName="", TString cutName="", TString outFolder="");
+TString NameOfTree = "tree";
+TString pathToTree = "";
+
+bool doSync = false;
+// Baseline
+//TString baseline = "TMET > 50 && TNJets >= 2 && THT > 300 && TNBtags >= 2 && TNTaus == 0 && !TIsOnZ";
+//TString CRZ      = "TMET > 50 && TNJets >= 2 && THT > 300 && TNBtags >= 2 && TNTaus == 0 && TIsOnZ";
+TString baseline = Form("TMET > 50 && TNJets >= 2 && THT > 300 && TNBtags >= 3 && !TIsOnZ && TPassTrigger %s", doSync? "" : "&& TPassMETFilters ") ;
+TString tauVeto  = doSync ? " && 1 " : " && TNTaus==0 ";
+TString CRZ      = tauVeto + "TMET > 50 && TNJets >= 2 && THT > 300 && TNBtags >= 2 && TIsOnZ";
+TString CRW      = baseline + tauVeto + "&& TNSelLeps == 2 && TNBtags == 2 && TNJets <= 5";
+TString CRT      = baseline + tauVeto + "&& TNSelLeps == 2 && TNBtags == 0 && TNJets >1";
+TString SR1      = baseline + tauVeto + "&& TNSelLeps == 2 && TNBtags == 2 && TNJets == 6";
+TString SR2      = baseline + tauVeto + "&& TNSelLeps == 2 && TNBtags == 2 && TNJets == 7";
+TString SR3      = baseline + tauVeto + "&& TNSelLeps == 2 && TNBtags == 2 && TNJets >= 8";
+TString SR4      = baseline + tauVeto + "&& TNSelLeps == 2 && TNBtags == 3 && (TNJets == 5 || TNJets == 6)";
+TString SR5      = baseline + tauVeto + "&& TNSelLeps == 2 && TNBtags == 3 && TNJets >= 7";
+TString SR6      = baseline + tauVeto + "&& TNSelLeps == 2 && TNBtags == 3 && TNJets >= 5";
+TString SR7      = baseline + tauVeto + "&& TNSelLeps == 3 && TNBtags == 2 && TNJets >= 5";
+TString SR8      = baseline + tauVeto + "&& TNSelLeps == 3 && TNBtags >= 3 && TNJets >= 4";
+TString SR9      = baseline + "&& TNSelLeps == 2 && TNTaus==1 && TChannel == iSS1tau && TNBtags >= 3";
+TString SR10     = baseline + "&& TNSelLeps == 2 && TNBtags == 3 && TNJets >=5 && TNTaus==1";
+
+
+TString NoFake   = Form("TChannel == %i || TChannel == %i || TChannel == %i || TChannel == %i", i2lss, iTriLep, iSS1tau, iOS1tau);
+
+void DrawPlots(TString cutName){
+  
+  TString username(gSystem->GetUserInfo(gSystem->GetUid())->fUser);
+  if(username=="vischia") pathToTree ="/nfs/fanae/user/juanr/AnalysisPAF/tttt_temp/";
+  else pathToTree = "/nfs/fanae/user/juanr/AnalysisPAF/Trees4t/jun15/";
+
+  TString cut;
+  if     (cutName == "CRW" ) cut = CRW ;
+  else if(cutName == "CRZ" ) cut = CRZ ;
+  else if(cutName == "CRT" ) cut = CRT ;
+  else if(cutName == "SR1" ) cut = SR1 ;
+  else if(cutName == "SR2" ) cut = SR2 ;
+  else if(cutName == "SR3" ) cut = SR3 ;
+  else if(cutName == "SR4" ) cut = SR4 ;
+  else if(cutName == "SR5" ) cut = SR5 ;
+  else if(cutName == "SR6" ) cut = SR6 ;
+  else if(cutName == "SR7" ) cut = SR7 ;
+  else if(cutName == "SR8" ) cut = SR8 ;
+  else if(cutName == "SR9" ) cut = SR9 ;
+  else if(cutName == "SR10") cut = SR10;
+  else {cout << "Wrong name!!" << endl; return;}
+
+  NoFake = (cutName=="SR9" || cutName=="SR10" || cutName=="CRT") ? "1" : NoFake; 
+
+  cut=baseline;
+  DrawPlot("TChannel",  cut, "SSTau", 1, 0, 15, "Count", cutName);
+  /*  DrawPlot("TNJets", "TNSelLeps == 2  && "  + baseline, "SS",       6, 2, 8, "Jet Multiplicity", "nJets");
+      DrawPlot("TNJets", "TNSelLeps >  2  && "  + baseline, "MultiLep", 6, 2, 8, "Jet Multiplicity", "nJets");
+      DrawPlot("TNJets",                          baseline, "All"     , 6, 2, 8, "Jet Multiplicity", "nJets");
+      DrawPlot("TNBtags", "TNSelLeps == 2  && " + baseline, "SS",       7, 0, 7, "b-jet Multiplicity", "nBJets");
+      DrawPlot("TNBtags", "TNSelLeps >  2  && " + baseline, "MultiLep", 7, 0, 7, "b-jet Multiplicity", "nBJets");
+      DrawPlot("TNBtags",                         baseline, "All"     , 7, 0, 7, "b-jet Multiplicity", "nBJets");
+      DrawPlot("THT", "TNSelLeps == 2  && "     + baseline, "SS",        16, 0, 1600, "HT [GeV]", "HT");
+      DrawPlot("THT", "TNSelLeps >  2  && "     + baseline, "MultiLep",  16, 0, 1600, "HT [GeV]", "HT");
+      DrawPlot("THT",                             baseline, "All"     ,  16, 0, 1600, "HT [GeV]", "HT");
+      DrawPlot("TMET", "TNSelLeps == 2  && "    + baseline, "SS",       15, 0, 600, "MET [GeV]", "MET");
+  DrawPlot("TMET", "TNSelLeps >  2  && "    + baseline, "MultiLep", 15, 0, 600, "MET [GeV]", "MET");
+*/  
+  // DrawPlot("TMET", "THT > 300 && TMET > 50 && TNTaus == 0",   Form("TChannel == %i || TChannel == %i", i2lss, iTriLep)     , 15, 0, 600, "MET [GeV]", "MET");
+  //DrawPlot("TMll", "THT > 300 && TMET > 50 && TNTaus == 0 && TNBtags >= 2 && TNJets >= 2",   Form("TChannel == %i || TChannel == %i", i2lss, iTriLep)     , 15, 0, 300, "InvMass [GeV]", "InvMass");
+
+ // DrawPlot("TMET", "TNJets >= 2",  "TChannel == 3"  , 15, 0, 600, "MET [GeV]", "MET");
+
+ gApplication->Terminate();
+}
+
+void DrawPlot(TString var, TString cut, TString chan, Int_t nbins, Float_t bin0, Float_t binN, TString Xtitle, TString varName, TString cutName, TString outFolder){
+  Plot* p = new Plot(var, cut, chan, nbins, bin0, binN, "Title", Xtitle);
+  if(outFolder!="") p->SetPlotFolder(outFolder);
+  p->SetPath(pathToTree); p->SetTreeName(NameOfTree);
+  p->verbose = true;
+//  p->doData = false;
+  if(varName != "") p->SetVarName(varName);
+  if(cutName != "") p->SetOutputName(cutName);
+
+  if(cutName.Contains("SR")) p->doData=false;
+  
+  p->AddSample("WZTo3LNu",                                        "WZ",       itBkg, kOrange);    // WZ
+  p->AddSample("WWTo2L2Nu, WpWpJJ, WWTo2L2Nu_DoubleScat",         "WW",       itBkg, kOrange-3);  // WW
+  p->AddSample("TGJets, TTGJets, WGToLNuG, ZGTo2LG",                "X+#gamma", itBkg, kViolet+2);  // X+gamma //"WZG_amcatnlo" "WWG_amcatnlo"
+  p->AddSample("WWW, WWZ, WZZ, ZZZ, ZZTo4L, VHToNonbb_amcatnlo, tZq_ll",    "Rare SM",  itBkg, kMagenta-7); // RareSM
+  p->AddSample("WZTo3LNu, WWTo2L2Nu, WpWpJJ, WWTo2L2Nu_DoubleScat", "Rare SM",  itBkg, kMagenta-7); // RareSM
+
+  // Nonprompt from MC
+  //p->AddSample("WJetsToLNu_MLM, DYJetsToLL_M5to50_MLM, DYJetsToLL_M50_MLM",                                 "Nonprompt", itBkg, kGray);
+  //p->AddSample("TTbar_Powheg, TW_noFullyHadr, TbarW_noFullyHadr, T_tch, Tbar_tch, TToLeptons_sch_amcatnlo", "Nonprompt", itBkg);
+
+  // Nonprompt from data
+	p->AddSample("MuonEG, DoubleEG, DoubleMuon",     "Nonprompt", itBkg, kGray, "0", "FakeLep");
+  p->AddSample("WZTo3LNu, WWTo2L2Nu,WpWpJJ,WWTo2L2Nu_DoubleScat, WWW, WWZ, WZZ, ZZZ, ZZTo4L, VHToNonbb_amcatnlo,TTZToLLNuNu, TTZToLL_M1to10, TTHNonbb, tZq_ll,TTWToLNu", "Nonprompt", itBkg, kGray, "0", "FakesubsLep");
+
+  // Charge misID
+  
+  p->AddSample("TTHNonbb",                                         "ttH",   itBkg,    kTeal+2);  // ttH
+  p->AddSample("TTZToLLNuNu, TTZToLL_M1to10",                      "ttZ",   itBkg,    kTeal+2);  // ttZ
+  p->AddSample("TTWToLNu",                                         "ttW",   itBkg,    kGreen+4); // ttW
+  p->AddSample("TTTT",                                             "tttt",  itSignal, kRed+1);   // tttt signal
+	p->AddSample("MuonEG, DoubleEG, DoubleMuon",                     "Data",  itData);             // Data
+
+  p->SetSignalProcess("tttt");
+  p->ScaleSignal(10);
+  p->SetSignalStyle("SM");
+
+  p->SetRatioMin(0.2);
+  p->SetRatioMax(1.8);
+
+  //p->AddSystematic("JES,Btag,MisTag,LepEff,PU");
+  p->AddSystematic("stat");
+  cout << "Selection = " << varName << endl;
+  cout << "Corresponding to cut: " << cut << endl;
+  p->PrintYields();
+  //p->PrintSamples();
+  p->doSetLogy = false;
+  p->DrawStack("0", 1);
+  //p->doSetLogy = true;
+  //p->DrawStack("log", 1);
+  //p->PrintSystYields();
+  delete p;
+}
+

--- a/plotter/WZ/Fakes.sh
+++ b/plotter/WZ/Fakes.sh
@@ -1,0 +1,16 @@
+# ====================
+# FAKES
+# ====================
+
+# DY, WJets
+root -l -b -q 'RunAnalyserPAF.C("WJetsToLNu_MLM & WJetsToLNu_MLM_ext2"            , "WZ",  16)'
+root -l -b -q 'RunAnalyserPAF.C("DYJetsToLL_M5to50_MLM"                           , "WZ", 40)'
+root -l -b -q 'RunAnalyserPAF.C("DYJetsToLL_M50_MLM_ext & DYJetsToLL_M50_MLM_ext2", "WZ", 60)'
+
+# ttbar, single-t
+root -l -b -q 'RunAnalyserPAF.C("TTbar_Powheg"           ,"WZ", 60)'
+root -l -b -q 'RunAnalyserPAF.C("T_tch"                  ,"WZ", 60)'
+root -l -b -q 'RunAnalyserPAF.C("Tbar_tch"               ,"WZ", 60)'
+root -l -b -q 'RunAnalyserPAF.C("TToLeptons_sch_amcatnlo","WZ", 60)'
+root -l -b -q 'RunAnalyserPAF.C("TbarW_noFullyHadr & TbarW_noFullyHadr_ext & TbarW_noFullyHadr_ext2"   ,"WZ", 60)'
+root -l -b -q 'RunAnalyserPAF.C("TW_noFullyHadr & TW_noFullyHadr_ext & TW_noFullyHadr_ext2"            ,"WZ", 60)'

--- a/plotter/WZ/Prompt.sh
+++ b/plotter/WZ/Prompt.sh
@@ -1,0 +1,23 @@
+# ====================
+# PROMPT
+# ====================
+# ttX
+root -l -b -q 'RunAnalyserPAF.C("TTWToLNu_ext1 & TTWToLNu_ext2"     ,"WZ",   16)'
+root -l -b -q 'RunAnalyserPAF.C("TTZToLLNuNu_ext1 & TTZToLLNuNu_ext2", "WZ",  16)'
+root -l -b -q 'RunAnalyserPAF.C("TTZToLL_M1to10", "WZ",8)' # TTZToLL_M-1to10_TuneCUETP8M1_13TeV-amcatnlo-pythia8
+root -l -b -q 'RunAnalyserPAF.C("TTHNonbb"                          , "WZ",  16)'
+root -l -b -q 'RunAnalyserPAF.C("tZq_ll"                            , "WZ", 1, -6)'
+root -l -b -q 'RunAnalyserPAF.C("TTTT"   , "WZ",16, -4)'
+
+#Di and tri bosons
+root -l -b -q 'RunAnalyserPAF.C("ZZTo4L"   ,   "WZ", 16 )' #root -l -b -q 'RunAnalyserPAF.C("ZZ & ZZ_ext"   ,"WZ", 8)'
+root -l -b -q 'RunAnalyserPAF.C("WZTo3LNu"   , "WZ", 16 )' #root -l -b -q 'RunAnalyserPAF.C("WZ & WZ_ext"   ,"WZ", 8)'
+root -l -b -q 'RunAnalyserPAF.C("WWTo2L2Nu"   ,"WZ", 60)' #root -l -b -q 'RunAnalyserPAF.C("WW & WW_ext"   ,"WZ", 8)'
+root -l -b -q 'RunAnalyserPAF.C("ZZZ"      ,"WZ",  16)'
+root -l -b -q 'RunAnalyserPAF.C("WZZ"      ,"WZ",  16)'
+root -l -b -q 'RunAnalyserPAF.C("WWZ"      ,"WZ",  16)'
+root -l -b -q 'RunAnalyserPAF.C("WWW"      ,"WZ",  16)'
+root -l -b -q 'RunAnalyserPAF.C("WpWpJJ"   ,"WZ", 60, -4)'
+root -l -b -q 'RunAnalyserPAF.C("VHToNonbb_amcatnlo"   ,"WZ", 20)' # VHToNonbb M125 13TeV amcatnloFXFX madspin pythia8
+root -l -b -q 'RunAnalyserPAF.C("WWTo2L2Nu_DoubleScat"   ,"WZ", 20)' # WW DoubleScattering 13TeV-pythia8
+

--- a/plotter/WZ/WZMiniTrees.sh
+++ b/plotter/WZ/WZMiniTrees.sh
@@ -1,0 +1,64 @@
+# ====================
+# FAKES
+# ====================
+
+# DY, WJets
+root -l -b -q 'RunAnalyserPAF.C("WJetsToLNu_MLM & WJetsToLNu_MLM_ext2"            , "WZ",  8)'
+root -l -b -q 'RunAnalyserPAF.C("DYJetsToLL_M5to50_MLM"                           , "WZ", 20)'
+root -l -b -q 'RunAnalyserPAF.C("DYJetsToLL_M50_MLM_ext & DYJetsToLL_M50_MLM_ext2", "WZ", 20)'
+
+# ttbar, single-t
+root -l -b -q 'RunAnalyserPAF.C("TTbar_Powheg"           ,"WZ", 30)'
+root -l -b -q 'RunAnalyserPAF.C("T_tch"                  ,"WZ", 30)'
+root -l -b -q 'RunAnalyserPAF.C("Tbar_tch"               ,"WZ", 30)'
+root -l -b -q 'RunAnalyserPAF.C("TToLeptons_sch_amcatnlo","WZ", 30)'
+root -l -b -q 'RunAnalyserPAF.C("TbarW_noFullyHadr & TbarW_noFullyHadr_ext & TbarW_noFullyHadr_ext2"   ,"WZ", 30)'
+root -l -b -q 'RunAnalyserPAF.C("TW_noFullyHadr & TW_noFullyHadr_ext & TW_noFullyHadr_ext2"            ,"WZ", 30)'
+
+
+# Inclusive samples, not dileptonic...
+
+# ====================
+# PROMPT
+# ====================
+# ttX
+root -l -b -q 'RunAnalyserPAF.C("TTWToLNu_ext1 & TTWToLNu_ext2"     ,"WZ",   8)'
+root -l -b -q 'RunAnalyserPAF.C("TTZToLLNuNu_ext1 & TTZToLLNuNu_ext2", "WZ",  8)'
+root -l -b -q 'RunAnalyserPAF.C("TTZToLL_M1to10", "WZ",8)' # TTZToLL_M-1to10_TuneCUETP8M1_13TeV-amcatnlo-pythia8
+root -l -b -q 'RunAnalyserPAF.C("TTHNonbb"                          , "WZ",  8)'
+root -l -b -q 'RunAnalyserPAF.C("tZq_ll"                            , "WZ", 1, -6)'
+
+#Di and tri bosons
+root -l -b -q 'RunAnalyserPAF.C("ZZTo4L"   ,   "WZ", 8 )' #root -l -b -q 'RunAnalyserPAF.C("ZZ & ZZ_ext"   ,"WZ", 8)'
+root -l -b -q 'RunAnalyserPAF.C("WZTo3LNu"   , "WZ", 8 )' #root -l -b -q 'RunAnalyserPAF.C("WZ & WZ_ext"   ,"WZ", 8)'
+root -l -b -q 'RunAnalyserPAF.C("WWTo2L2Nu"   ,"WZ", 30)' #root -l -b -q 'RunAnalyserPAF.C("WW & WW_ext"   ,"WZ", 8)'
+root -l -b -q 'RunAnalyserPAF.C("ZZZ"      ,"WZ",  8)'
+root -l -b -q 'RunAnalyserPAF.C("WZZ"      ,"WZ",  8)'
+root -l -b -q 'RunAnalyserPAF.C("WWZ"      ,"WZ",  8)'
+root -l -b -q 'RunAnalyserPAF.C("WWW"      ,"WZ",  8)'
+root -l -b -q 'RunAnalyserPAF.C("WpWpJJ"   ,"WZ", 30, -4)'
+root -l -b -q 'RunAnalyserPAF.C("VHToNonbb_amcatnlo"   ,"WZ", 5)' # VHToNonbb M125 13TeV amcatnloFXFX madspin pythia8
+root -l -b -q 'RunAnalyserPAF.C("WWTo2L2Nu_DoubleScat"   ,"WZ", 5)' # WW DoubleScattering 13TeV-pythia8
+
+# ====================
+# CONVERSIONS
+# ====================
+root -l -b -q 'RunAnalyserPAF.C("TGJets & TGJets_ext"  , "WZ",8, -4)'
+root -l -b -q 'RunAnalyserPAF.C("TTGJets & TTGJets_ext", "WZ",30   )'
+root -l -b -q 'RunAnalyserPAF.C("WGToLNuG"             , "WZ",8, -4)'
+root -l -b -q 'RunAnalyserPAF.C("ZGTo2LG"              , "WZ",8, -4)'
+root -l -b -q 'RunAnalyserPAF.C("WZG_amcatnlo"   , "WZ",8, -4)' # WZG_TuneCUETP8M1_13TeV-amcatnlo-pythia8
+root -l -b -q 'RunAnalyserPAF.C("WWG_amcatnlo"   , "WZ",8)' # WWG_TuneCUETP8M1_13TeV-amcatnlo-pythia8
+
+# ====================
+# SIGNAL
+# ====================
+root -l -b -q 'RunAnalyserPAF.C("TTTT"   , "WZ",8, -4)'
+
+# ====================
+# DATA
+# ====================
+root -l -b -q 'RunAnalyserPAF.C("MuonEG"    , "WZ",40)'
+root -l -b -q 'RunAnalyserPAF.C("DoubleMuon", "WZ",40)'
+root -l -b -q 'RunAnalyserPAF.C("DoubleEG"  , "WZ",40)'
+

--- a/plotter/WZ/batch.sh
+++ b/plotter/WZ/batch.sh
@@ -1,0 +1,4 @@
+# Run me from outside the plotter.
+
+# Running with -q proof is only different in that it has a small time limit (~2h). -q batch has a 2 days limit
+qsub -q batch -l nodes=1:ppn=30 plotter/WZ/submit.sh

--- a/plotter/WZ/doAnal.sh
+++ b/plotter/WZ/doAnal.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Everything is gonna be run from outside the plotter
+
+if [ "$1" == "batch" ]; then
+    source plotter/WZ/batch.sh
+
+elif [ "$1" == "yields" ]; then    
+    root -l -b plotter/WZ/yields.C\(\"~/www/t4/plots\"\)
+elif [ "$1" == "plots" ]; then
+    cd plotter
+    #root -l -b t4/DrawPlots.C\(\"CRT\"\)
+    root -l -b t4/DrawPlots.C\(\"SR9\"\)
+    root -l -b t4/DrawPlots.C\(\"SR10\"\)
+    cd -
+else
+    echo "Es que no me hás dicho que hacer, así que mejor si me duermo."
+
+fi

--- a/plotter/WZ/submit.sh
+++ b/plotter/WZ/submit.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+pwd
+cd /mnt_pool/ciencias_users/user/carlosec/WZ/AnalysisPAF/
+source /cms/slc6_amd64_gcc530/external/gcc/5.3.0/etc/profile.d/init.sh; source /cms/slc6_amd64_gcc530/external/python/2.7.11-giojec2/etc/profile.d/init.sh; source /cms/slc6_amd64_gcc530/external/python/2.7.11-giojec2/etc/profile.d/dependencies-setup.sh; source /cms/slc6_amd64_gcc530/external/cmake/3.5.2/etc/profile.d/init.sh;source /opt/root6/bin/thisroot.sh
+
+source /opt/PAF/PAF_setup.sh
+
+sh plotter/WZ/WZMiniTrees.sh

--- a/plotter/WZ/yields.C
+++ b/plotter/WZ/yields.C
@@ -1,0 +1,140 @@
+R__LOAD_LIBRARY(plotter/Histo.C+)
+R__LOAD_LIBRARY(plotter/Looper.C+)
+R__LOAD_LIBRARY(plotter/Plot.C+)
+R__LOAD_LIBRARY(plotter/TResultsTable.C+)
+R__LOAD_LIBRARY(plotter/CrossSection.C+)
+#include "../Histo.h"
+#include "../Looper.h"
+#include "../Plot.h"
+
+void DrawPlot(TString var, TString cut, TString chan, Int_t nbins, Float_t bin0, Float_t binN, TString Xtitle, TString name = "");
+
+TString NameOfTree = "tree";
+
+TString alwaystrue("1");
+TString presel("TMT2>0 && TIsSS && TNFakeableLeps < 3"); // MT2 falta de los trees
+TString SRs(presel+" && TNBtags>=2 && TNJets >=2 && TMET>50 && THT > 300");
+TString CRs(presel+" && TNBtags<2 && TNJets>0");
+
+TString pathToTree("./tttt_temp/");
+
+void yields(TString plotsFolder=""){
+  Plot* p = new Plot("TChannel", alwaystrue, "1", 1, 0, 10, "Channel", "xsec");
+  TString username(gSystem->GetUserInfo(gSystem->GetUid())->fUser);
+  if(username=="vischia") pathToTree="/pool/ciencias/userstorage/pietro/tttt/2l_skim_wmt2/tttt_temp/";
+  p->SetPath(pathToTree); p->SetTreeName(NameOfTree);
+  p->verbose = true;
+  p->SetPlotFolder(plotsFolder);
+  //p->doData = false;
+  //p->doStackSignal = true;
+
+  // Diboson
+  p->AddSample("ZZTo4L"   , "VV non-WZ", itBkg, kYellow-10, 0.50);
+  p->AddSample("WWTo2L2Nu", "VV non-WZ", itBkg);  
+  p->AddSample("WpWpJJ"   , "VV non-WZ", itBkg);
+  
+  // Triboson
+  p->AddSample("ZZZ", "VVV", itBkg);
+  p->AddSample("WZZ", "VVV", itBkg);
+  p->AddSample("WWZ", "VVV", itBkg);
+  p->AddSample("WWW", "VVV", itBkg);
+  
+  // ttV
+  p->AddSample("TTZToLLNuNu1"  , "ttV", itBkg, kOrange-3, 0.5);
+  p->AddSample("TTWToLNu1"     , "ttV", itBkg);
+  p->AddSample("TTZToLL_M1to10", "ttV", itBkg);
+
+  // ttH/tZq
+  p->AddSample("tZq_ll",   "tZq", itBkg, kOrange-1, 0.5);
+  //p->AddSample("TTHNonbb", "ttH/tZq", itBkg); // Must run from jet25, but need jet15
+
+  // WZ
+  p->AddSample("WZTo3LNu",     "WZ", itBkg);
+
+  // tW
+  p->AddSample("T_tch"                  ,"t/tW", itBkg, kMagenta, 0.2);
+  p->AddSample("Tbar_tch"               ,"t/tW", itBkg);
+  p->AddSample("TToLeptons_sch_amcatnlo","t/tW", itBkg);
+  p->AddSample("TW_noFullyHadr"         ,"t/tW", itBkg);
+  p->AddSample("TbarW_noFullyHadr"      ,"t/tW", itBkg);
+  
+  // tt
+  p->AddSample("TTbar_Powheg", "tt", itBkg, kRed+1, 0.05);
+  //p->AddSample("TTbar_Powheg_Semi", "NonWZ", itBkg, kGreen-2, 0.50);  
+
+  // Conversions
+  p->AddSample("TGJets"      , "Conversions", itBkg, kBlue-1, 0.5);
+  p->AddSample("TTGJets"     , "Conversions", itBkg);
+  p->AddSample("WGToLNuG"    , "Conversions", itBkg);
+  p->AddSample("ZGTo2LG"     , "Conversions", itBkg);
+  p->AddSample("WZG_amcatnlo", "Conversions", itBkg);
+  p->AddSample("WWG_amcatnlo", "Conversions", itBkg);
+
+  // V+jets
+  p->AddSample("WJetsToLNu_MLM"       , "WJets", itBkg, kAzure-4, 0.50);
+  p->AddSample("DYJetsToLL_M50_MLM"   , "DY"   , itBkg, kAzure-8, 0.50);
+  p->AddSample("DYJetsToLL_M5to50_MLM", "DY"   , itBkg);
+  // Substitute with DY/WJets  aMCatNLO?
+  //p->AddSample("WJetsToLNu_aMCatNLO", "WJets", itBkg, kAzure-4, 0.50);
+  //p->AddSample("DYJetsToLL_M50_aMCatNLO", "DY", itBkg, kAzure-8, 0.50);
+  //p->AddSample("DYJetsToLL_M10to50_aMCatNLO",     "DY", itBkg);
+
+  // Signal
+  p->AddSample("TTTT"   , "TTTT", itSignal, kRed, 0.10);
+
+  p->AddSample("DoubleEG"  , "Data", itData);
+  p->AddSample("DoubleMuon", "Data", itData);
+  p->AddSample("MuonEG"    , "Data", itData);
+  //// p->AddSample("SingleMuon", "Data", itData);
+  //// p->AddSample("SingleElec", "Data", itData);
+
+
+/*
+  p->AddSample("TTbar_Powheg_ueUp", "ttbar", itSys, 1, 0, "ueUp");
+  p->AddSample("TTbar_Powheg_ueDown", "ttbar", itSys, 1, 0, "ueDown");
+  p->AddSample("TTbar_Powheg_isrUp", "ttbar", itSys, 1, 0, "isrUp");
+  p->AddSample("TTbar_Powheg_isrDown", "ttbar", itSys, 1, 0, "isrDown");
+  p->AddSample("TTbar_Powheg_fsrUp", "ttbar", itSys, 1, 0, "fsrUp");
+  p->AddSample("TTbar_Powheg_fsrDown", "ttbar", itSys, 1, 0, "fsrDown");
+  p->AddSample("TTJets_aMCatNLO", "ttbar", itSys, 1, 0, "nloUp");
+  p->AddSample("TTbar_PowhegLHE", "ttbar", itSys, 1, 0, "nloDown");
+  p->AddSample("TTbar_Powheg_Herwig", "ttbar", itSys, 1, 0, "hadUp");
+  p->AddSample("TTbar_PowhegLHE", "ttbar", itSys, 1, 0, "hadDown");
+*/
+
+
+  p->AddSystematic("stat");
+  // p->AddSystematic("JES");
+  //p->PrintYields(dilepton + ", " + jets2 + ", " + btag1, "Dilepton, 2jets, 1btag", "ElMu, ElMu, ElMu");
+  //p->PrintYields("", "", "", "html");
+  
+  p->SetYieldsTableName("inclusive"); p->PrintYields(presel + ", " + SRs + ", " + CRs, "Preselection, Signal Regions, Control Regions", "   1,    1,    1", "html");
+  p->SetYieldsTableName("emu"      ); p->PrintYields(presel + ", " + SRs + ", " + CRs, "Preselection, Signal Regions, Control Regions", Form("TChannel==%i, TChannel==%i, TChannel==%i",iElMu,iElMu,iElMu), "html");
+  p->SetYieldsTableName("ee"       ); p->PrintYields(presel + ", " + SRs + ", " + CRs, "Preselection, Signal Regions, Control Regions", Form("TChannel==%i, TChannel==%i, TChannel==%i",iElec,iElec,iElec), "html");
+  p->SetYieldsTableName("mumu"     ); p->PrintYields(presel + ", " + SRs + ", " + CRs, "Preselection, Signal Regions, Control Regions", Form("TChannel==%i, TChannel==%i, TChannel==%i",iMuon,iMuon,iMuon), "html");
+
+
+  //CrossSection *x = new CrossSection(p, "ttbar");
+  //x->SetTheoXsec(831.8);
+  //x->SetChannelTag("ElMu");
+  //x->SetLevelTag(">2jets");
+  //x->PrintSystematicTable();
+  //x->SetBR();
+
+
+  //p->ScaleProcess("VV", 2.);
+  //p->PrintYields();
+
+  //p->PrintSamples();
+  //p->PrintSystYields();
+  //p->PrintYields("TMET > 50, TMET > 50, TMET > 50", "ElMu, Elec, Muon", "ElMu, Elec, Muon");
+  //p->DrawStack("prueba", 1);
+ 
+  //Plot* k = p->NewPlot("TMET", "TMET > 200");
+  //k->PrintYields();
+  //k->PrintSamples();
+  //k->PrintSystYields();
+
+  //delete p;
+}
+


### PR DESCRIPTION
First implementation of the inclusive WZ analysis following  @vischia 's code at:

[https://github.com/vischia/cmgtools-lite/tree/wz80x/](https://github.com/vischia/cmgtools-lite/tree/wz80x/)

The following items are currently missing:
-Fake estimation with fakerate maps (currently using MC truth).
-Properly fill the non-miniTree histograms in the output.

The following items were added:
-Lepton selection categories (loose, fakeable object, tight) with multiple IDs (top-like, multiple leptonMVA categories).
-Event selection following the WZ analysis.
-Lepton assignation to W/Z bosons and relevant mass-like variables computation.
